### PR TITLE
Oprava názvu odkazu na sekci "Pro média" v navigaci webu

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -21,7 +21,7 @@ block content
           li
             a.btn.nav__link(href='#team') Kdo jsme
           li
-            a.btn.nav__link(href='#media') Pro media
+            a.btn.nav__link(href='#media') Pro média
           li
             a.btn.nav__link(href='en.html') English
           


### PR DESCRIPTION
Změna "Pro media" na "Pro média" 

(Všiml jsem si toho při studiu CSS pro blog, tak rovnou posílám mikroskopický pull request.)