### PR TITLE
Add Slack invite link to simplify signup for new users

### DIFF
--- a/src/en.pug
+++ b/src/en.pug
@@ -30,7 +30,7 @@ block content
           | We are a community of top developers, designers and production people who want to use their free time to help state and non-governmental organizations and make Czechia a better place to live.
         ul.hero__cta
           li.hero__cta-item
-            a.btn.btn--cta(href='https://slack.cesko.digital/') Join us
+            a.btn.btn--cta(href='https://join.slack.com/t/cesko-digital/shared_invite/zt-6ygukc79-RwoSj8b90rZx1_4P_oJHow') Join us
           li.hero__cta-item
             a.btn.btn--cta(href='https://forms.gle/yAxPSueBJgyffEGi8') Submit project
 

--- a/src/index.pug
+++ b/src/index.pug
@@ -33,7 +33,7 @@ block content
           | Jsme komunita špičkových vývojářů, designérů a produkťáků, kteří chtějí ve svém volném čase pomáhat státu i nestátním organizacím a dělat tak Česko lepším místem k životu.
         ul.hero__cta
           li.hero__cta-item
-            a.btn.btn--cta(href='https://slack.cesko.digital/') Přidej se k nám
+            a.btn.btn--cta(href='https://join.slack.com/t/cesko-digital/shared_invite/zt-6ygukc79-RwoSj8b90rZx1_4P_oJHow') Přidej se k nám
           li.hero__cta-item
             a.btn.btn--cta(href='https://forms.gle/yAxPSueBJgyffEGi8') Přihlas projekt
 


### PR DESCRIPTION
As discussed on [Slack](https://cesko-digital.slack.com/archives/CSXGU7F0F/p1584121928205000), we can use [invitation link](https://slack.com/intl/en-cz/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invite-link) to simplify signup for new users.