### PR TITLE
Automatická kontrola na větvi rework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Test
+      run: |
+        yarn install
+        yarn lint
+        yarn test


### PR DESCRIPTION
Všechny PR a pushe do větve `rework` by měly spustit `yarn test && yarn lint`.

Fixes #43.