### PR TITLE
remove unnecessary font-weight change

### DIFF
--- a/src/components/links/link/styles.ts
+++ b/src/components/links/link/styles.ts
@@ -114,11 +114,5 @@ export const applyLinkStyles = ({
 
     ${getColor({ size, disabled })};
     ${getBorderStyle({ size, disabled })};
-
-    &:hover,
-    &:focus {
-      font-weight: ${({ theme }) =>
-        size === Small ? 300 : theme.fontWeights.button};
-    }
   `
 }


### PR DESCRIPTION
Oprava font-weight on hover, focus pro odkaz typu Small #109

Odstranil jsem úplně pravidlo o font-weight on hover. Ze zadání jsem úplně nepochopil toto: "(ne změna hodnoty, vyjímka z CSS selektoru)."
Tak jsem udělal tak, jak jsem usoudil, že to má být. Prosím o feedback, jestli jsem všechno udělal tak, jak odpovídá konvencím. Koukám, že dle CONTRIBUTING je v PR čeština, ale na názvy tu všichni používají angličtinu, tak jsem se přizpůsobil.