### PR TITLE
Přesměrování /prirucka na repo Příručky

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,9 @@
+{
+    "redirects": [
+        {
+            "source": "/prirucka",
+            "destination": "https://github.com/cesko-digital/derisking-handbook",
+            "statusCode": 302
+        }
+    ]
+}


### PR DESCRIPTION
Tohle nám funguje na starém webu a nejspíš bysme v rámci stability URL měli zavést i na novém webu.

Checklist pro nové změny:

- [x] Kód je v souladu s [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Změny byly krátce otestovány v Chrome, Safari, případně dalších prohlížečích
- [x] Git log neboli historie commitů je čistá (rozdělení do více commitů je možné pokud se jedná o odlišný kontext změn, např. nutný refactoring něčeho jiného)
