### PR TITLE
Draft of Show&Tell micro-site

### DIFF
--- a/src/pages/rsvp.tsx
+++ b/src/pages/rsvp.tsx
@@ -4,7 +4,7 @@ import * as S from 'components/typography'
 import { Input } from 'components/inputs'
 import { Button } from 'components/buttons'
 import { FormikErrors, useFormik } from 'formik'
-import { EMAIL_REGEX } from '../../../api/newsletter'
+import { EMAIL_REGEX } from '../../api/newsletter'
 import { PageProps } from 'gatsby'
 
 const submitUrl =
@@ -14,10 +14,10 @@ interface ShowAndTellFormValues {
   email: string
 }
 
-const ShowAndTell: React.FC<PageProps> = ({ location }) => {
+const Rsvp: React.FC<PageProps> = ({ location }) => {
   const [registered, setRegistered] = useState(false)
   const id = new URLSearchParams(location.search).get('id')
-  const showEmail = id === null
+  const showEmail = !id
 
   const validate = (
     values: ShowAndTellFormValues
@@ -95,4 +95,4 @@ const ShowAndTell: React.FC<PageProps> = ({ location }) => {
   )
 }
 
-export default ShowAndTell
+export default Rsvp

--- a/src/pages/rsvp.tsx
+++ b/src/pages/rsvp.tsx
@@ -6,9 +6,10 @@ import { Button } from 'components/buttons'
 import { FormikErrors, useFormik } from 'formik'
 import { EMAIL_REGEX } from '../../api/newsletter'
 import { PageProps } from 'gatsby'
+import * as Links from 'components/links'
+import styled from 'styled-components'
 
-const submitUrl =
-  'https://cd-tools-git-feature-rsvp-ceskodigital.vercel.app/rsvp'
+const submitUrl = 'https://cesko.digital/api/rsvp'
 
 interface ShowAndTellFormValues {
   email: string
@@ -65,17 +66,28 @@ const Rsvp: React.FC<PageProps> = ({ location }) => {
       crumbs={[]}
       seo={{
         title: 'Show&Tell',
-        description: 'Prezentace dobrovolníků Česko.Digital',
+        description:
+          'Pravidelné živé vysílání prezentace práce dobrovolníků Česko.Digital',
       }}
     >
       <Section>
         <SectionContent>
           <S.Heading1>Show&Tell</S.Heading1>
           <p>
-            Ve čtvrtek 29. dubna v 18:00 proběhne první živé výsílání Show&Tell
-            Česko.Digital.
+            V rámci Česko.Digital prezentujeme krásné výsledky projektů, ale v
+            tiskových zprávách není vidět množství práce dobrovolníků, které za
+            úspšchy projektů stojí.
           </p>
-          <form onSubmit={form.handleSubmit}>
+          <p>
+            Show&Tell má cíl tohle změnit a dát šanci dobrovolníkům prezentovat
+            jejich cestu k výsledku.
+          </p>
+          <p>
+            Event se koná jednou měsíčně vždy podlení čtvrtek. Nejbližsí
+            vysílání se koná <b>29. dubna od 18:00</b> a můžete ho sledovat{' '}
+            <Links.Link to="/show-and-tell">zde</Links.Link>.
+          </p>
+          <Form onSubmit={form.handleSubmit}>
             {showEmail && !registered && (
               <Input
                 name="email"
@@ -88,11 +100,16 @@ const Rsvp: React.FC<PageProps> = ({ location }) => {
             <Button type="submit">
               {registered ? 'Je to tam!' : 'Chci to do kalendáře!'}
             </Button>
-          </form>
+          </Form>
         </SectionContent>
       </Section>
     </Layout>
   )
 }
+
+const Form = styled.form`
+  margin-top: 32px;
+  margin-bottom: 50px;
+`
 
 export default Rsvp

--- a/src/pages/rsvp/showandtell.tsx
+++ b/src/pages/rsvp/showandtell.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import { Layout, Section, SectionContent } from '../../components/layout'
+import * as S from '../../page-components/projects/styles'
+import { ProjectsProps } from '../../components/sections/projects'
+import { Input } from '../../components/inputs'
+import { Button } from '../../components/buttons'
+import { FormikErrors, useFormik } from 'formik'
+import { EMAIL_REGEX } from '../../../api/newsletter'
+
+const submitUrl =
+  'https://cd-tools-git-feature-rsvp-ceskodigital.vercel.app/rsvp'
+
+interface ShowAndTellFormValues {
+  email: string
+}
+
+const ShowAndTell: React.FC<ProjectsProps> = () => {
+  const [registered, setRegistered] = useState(false)
+  const showEmail = new URLSearchParams(location.search).get('id') == null
+
+  const validate = (
+    values: ShowAndTellFormValues
+  ): FormikErrors<ShowAndTellFormValues> => {
+    if (showEmail) {
+      if (!EMAIL_REGEX.test(values.email)) {
+        return {
+          email: 'Nevalidní email',
+        }
+      }
+    }
+    return {}
+  }
+
+  const onSubmit = (values: ShowAndTellFormValues) => {
+    if (!registered) {
+      // Fire&Forget
+      setRegistered(true)
+
+      const body = showEmail
+        ? values
+        : {
+            id: new URLSearchParams(location.search).get('id'),
+          }
+
+      fetch(submitUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+    }
+  }
+
+  const form = useFormik<ShowAndTellFormValues>({
+    initialValues: {
+      email: '',
+    },
+    validate,
+    onSubmit,
+  })
+
+  return (
+    <Layout
+      crumbs={[]}
+      seo={{
+        title: '',
+        description: '',
+      }}
+    >
+      <Section>
+        <SectionContent>
+          <S.Heading>Show&Tell</S.Heading>
+          <S.Tagline>Bude to super!</S.Tagline>
+        </SectionContent>
+      </Section>
+      <Section>
+        <SectionContent>
+          <S.ProjectsHeading>Program</S.ProjectsHeading>
+          {showEmail && !registered && (
+            <Input
+              name="email"
+              placeholder="Vaše emailová adresa"
+              onChange={form.handleChange}
+              onBlur={form.handleBlur}
+              invalid={form.errors.email != null}
+            />
+          )}
+          <Button onClick={form.handleSubmit}>
+            {registered ? 'Je to tam!' : 'Chci to do kalendáře!'}
+          </Button>
+        </SectionContent>
+      </Section>
+    </Layout>
+  )
+}
+
+export default ShowAndTell

--- a/src/pages/rsvp/showandtell.tsx
+++ b/src/pages/rsvp/showandtell.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { Layout, Section, SectionContent } from '../../components/layout'
-import * as S from '../../page-components/projects/styles'
-import { Input } from '../../components/inputs'
-import { Button } from '../../components/buttons'
+import { Layout, Section, SectionContent } from 'components/layout'
+import * as S from 'components/typography'
+import { Input } from 'components/inputs'
+import { Button } from 'components/buttons'
 import { FormikErrors, useFormik } from 'formik'
 import { EMAIL_REGEX } from '../../../api/newsletter'
 import { PageProps } from 'gatsby'
@@ -16,7 +16,8 @@ interface ShowAndTellFormValues {
 
 const ShowAndTell: React.FC<PageProps> = ({ location }) => {
   const [registered, setRegistered] = useState(false)
-  const showEmail = new URLSearchParams(location.search).get('id') == null
+  const id = new URLSearchParams(location.search).get('id')
+  const showEmail = id === null
 
   const validate = (
     values: ShowAndTellFormValues
@@ -39,7 +40,7 @@ const ShowAndTell: React.FC<PageProps> = ({ location }) => {
       const body = showEmail
         ? values
         : {
-            id: new URLSearchParams(location.search).get('id'),
+            id,
           }
 
       fetch(submitUrl, {
@@ -70,25 +71,22 @@ const ShowAndTell: React.FC<PageProps> = ({ location }) => {
     >
       <Section>
         <SectionContent>
-          <S.Heading>Show&Tell</S.Heading>
-          <S.Tagline>Bude to super!</S.Tagline>
-        </SectionContent>
-      </Section>
-      <Section>
-        <SectionContent>
-          <S.ProjectsHeading>Program</S.ProjectsHeading>
-          {showEmail && !registered && (
-            <Input
-              name="email"
-              placeholder="Vaše emailová adresa"
-              onChange={form.handleChange}
-              onBlur={form.handleBlur}
-              invalid={form.errors.email != null}
-            />
-          )}
-          <Button onClick={form.handleSubmit}>
-            {registered ? 'Je to tam!' : 'Chci to do kalendáře!'}
-          </Button>
+          <S.Heading1>Show&Tell</S.Heading1>
+          <p>Bude to super!</p>
+          <form onSubmit={form.handleSubmit}>
+            {showEmail && !registered && (
+              <Input
+                name="email"
+                placeholder="Vaše emailová adresa"
+                onChange={form.handleChange}
+                onBlur={form.handleBlur}
+                invalid={!!form.errors.email}
+              />
+            )}
+            <Button type="submit">
+              {registered ? 'Je to tam!' : 'Chci to do kalendáře!'}
+            </Button>
+          </form>
         </SectionContent>
       </Section>
     </Layout>

--- a/src/pages/rsvp/showandtell.tsx
+++ b/src/pages/rsvp/showandtell.tsx
@@ -14,7 +14,7 @@ interface ShowAndTellFormValues {
   email: string
 }
 
-const ShowAndTell: React.FC<ProjectsProps> = () => {
+const ShowAndTell: React.FC<ProjectsProps> = ({ location }) => {
   const [registered, setRegistered] = useState(false)
   const showEmail = new URLSearchParams(location.search).get('id') == null
 

--- a/src/pages/rsvp/showandtell.tsx
+++ b/src/pages/rsvp/showandtell.tsx
@@ -37,18 +37,17 @@ const ShowAndTell: React.FC<PageProps> = ({ location }) => {
       // Fire&Forget
       setRegistered(true)
 
-      const body = showEmail
-        ? values
-        : {
-            id,
-          }
+      const userId = showEmail ? values.email : id
 
       fetch(submitUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(body),
+        body: JSON.stringify({
+          eventId: 'recRkEEj5rEkm92IS',
+          userId,
+        }),
       })
     }
   }
@@ -65,14 +64,17 @@ const ShowAndTell: React.FC<PageProps> = ({ location }) => {
     <Layout
       crumbs={[]}
       seo={{
-        title: '',
-        description: '',
+        title: 'Show&Tell',
+        description: 'Prezentace dobrovolníků Česko.Digital',
       }}
     >
       <Section>
         <SectionContent>
           <S.Heading1>Show&Tell</S.Heading1>
-          <p>Bude to super!</p>
+          <p>
+            Ve čtvrtek 29. dubna v 18:00 proběhne první živé výsílání Show&Tell
+            Česko.Digital.
+          </p>
           <form onSubmit={form.handleSubmit}>
             {showEmail && !registered && (
               <Input

--- a/src/pages/rsvp/showandtell.tsx
+++ b/src/pages/rsvp/showandtell.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 import { Layout, Section, SectionContent } from '../../components/layout'
 import * as S from '../../page-components/projects/styles'
-import { ProjectsProps } from '../../components/sections/projects'
 import { Input } from '../../components/inputs'
 import { Button } from '../../components/buttons'
 import { FormikErrors, useFormik } from 'formik'
 import { EMAIL_REGEX } from '../../../api/newsletter'
+import { PageProps } from 'gatsby'
 
 const submitUrl =
   'https://cd-tools-git-feature-rsvp-ceskodigital.vercel.app/rsvp'
@@ -14,7 +14,7 @@ interface ShowAndTellFormValues {
   email: string
 }
 
-const ShowAndTell: React.FC<ProjectsProps> = ({ location }) => {
+const ShowAndTell: React.FC<PageProps> = ({ location }) => {
   const [registered, setRegistered] = useState(false)
   const showEmail = new URLSearchParams(location.search).get('id') == null
 

--- a/src/pages/show-and-tell.tsx
+++ b/src/pages/show-and-tell.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { Layout, Section, SectionContent } from 'components/layout'
+import * as S from 'components/typography'
+import * as Links from 'components/links'
+import { PageProps } from 'gatsby'
+import styled from 'styled-components'
+
+const ShowAndTell: React.FC<PageProps> = () => {
+  return (
+    <Layout
+      crumbs={[{ label: 'Show&Tell' }]}
+      seo={{
+        title: 'Show&Tell',
+        description:
+          'Pravidelné živé vysílání prezentace práce dobrovolníků Česko.Digital',
+      }}
+    >
+      <Section>
+        <SectionContent>
+          <TwoColumnLayout>
+            <MainColumn>
+              <S.Heading1>Show&Tell</S.Heading1>
+              <p>
+                Ve čtvrtek 29. dubna v 18:00 proběhne první živé výsílání
+                Show&Tell Česko.Digital.
+              </p>
+              <VideoWrapper>
+                <VideoIFrame
+                  src="https://www.youtube.com/embed/vnFuzxKlyb4"
+                  title="Show&Tell"
+                  frameBorder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              </VideoWrapper>
+            </MainColumn>
+            <ReminderColumn>
+              <S.Heading3>Co mě čeká?</S.Heading3>
+              <p>
+                V dubnovém vysílání se dozvíte detaily z vývoje a designování:
+              </p>
+              <ul>
+                <li>Střechy Duševního Zdraví</li>
+                <li>Nedlužím státu</li>
+                <li>Nového webu č.d</li>
+                <li>Onboardingu dobrovolníků</li>
+              </ul>
+              <p>
+                Jako bonus vám představíme detaily z vývoje Projektu Tlačítko,
+                které si můžete vyzkoušet níže a přidat si nás do kalendáře.
+              </p>
+              <Links.Link to="/rsvp">Chci to do kalendáře!</Links.Link>
+            </ReminderColumn>
+          </TwoColumnLayout>
+        </SectionContent>
+      </Section>
+    </Layout>
+  )
+}
+
+const VideoWrapper = styled.div`
+  position: relative;
+  padding-top: 56.25%;
+`
+
+const VideoIFrame = styled.iframe`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
+const TwoColumnLayout = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  margin-bottom: 50px;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.lg}) {
+    flex-direction: column;
+  }
+`
+
+const MainColumn = styled.div`
+  flex-grow: 1;
+`
+
+const ReminderColumn = styled.div`
+  max-width: 400px;
+  margin-left: 32px;
+  
+    @media (max-width: ${({ theme }) => theme.breakpoints.lg}) {
+    margin-left: 0px;
+    max-width: 1024px;s
+  }
+`
+
+export default ShowAndTell


### PR DESCRIPTION
Pridana micro-site pro Show&Tell event.

Uzivatel prijde na stranku, dostane info a ma zde tlacitko. Pokud bude v URL Get parameter id=XYZ tlacitko posle na RSVP lambdu tohle ID. Na strance bez id v parametru se navic zepta na email a odesle ho misto id.

Url je k diskuzi. Ted je to:
/rsvp/showandtell?id=1 pro variantu bez emailu a /rsvp/showandtell pro variantu s emailem.

Checklist pro nové změny:

- [ ] Kód je v souladu s [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] Nové vizuální komponenty jsou ve Storybooku včetně dokumentace jejich rozhraní
- [ ] HTML je semanticky správně strukturované (headings, odstavce, seznamy atd.)
- [ ] Nové závislosti není možné nahradit vlastní jednoduchou implementací, jsou pod správnou open source licencí a [jejích velikost je přijatelná](https://bundlephobia.com/)
- [ ] Veškerá logika má jednoduché pokrytí unit testy
- [ ] Ilustrace a ikony jsou vloženy jako [React SVG komponenta](https://react-svgr.com/playground/)
- [ ] Design odpovídá Figmě
- [ ] Změny byly krátce otestovány v Chrome, Safari, případně dalších prohlížečích
- [ ] Git log neboli historie commitů je čistá (rozdělení do více commitů je možné pokud se jedná o odlišný kontext změn, např. nutný refactoring něčeho jiného)
