### PR TITLE
odbarvit obrázek zvýrazněného projektu

### DIFF
--- a/src/page-components/projects/sections/highlighted-project/styles.ts
+++ b/src/page-components/projects/sections/highlighted-project/styles.ts
@@ -57,6 +57,7 @@ export const ProjectImage = styled.div<{ src: string }>`
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center left;
+  filter: grayscale(100%);
 
   @media (min-width: ${({ theme }) => theme.breakpoints.sm}) {
     border-top-right-radius: ${({ theme }) => theme.borderRadius.base}px;


### PR DESCRIPTION
Fixes #265.

před:
<img src="https://user-images.githubusercontent.com/25487857/120883790-79656880-c5df-11eb-95f6-c5d9e7cabfc5.png" width="400">

po:
<img src="https://user-images.githubusercontent.com/25487857/120883774-63f03e80-c5df-11eb-816b-ff649fc5d205.png" width="400">

Za mě to u tohoto konkrétního obrázku vypadá dobře i barevné, ale nechám na vás, u ostatních to tak být nemusí. :) 


Checklist pro nové změny:

- [x] Kód je v souladu s [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Design odpovídá Figmě
- [x] Změny byly krátce otestovány v Chrome, Safari, případně dalších prohlížečích
- [x] Git log neboli historie commitů je čistá (rozdělení do více commitů je možné pokud se jedná o odlišný kontext změn, např. nutný refactoring něčeho jiného)
