### PR TITLE
Přepis RSVP endpointu pro Portál dobrovolníka

### DIFF
--- a/api/rsvp.ts
+++ b/api/rsvp.ts
@@ -47,7 +47,7 @@ export default async (
         filterByFormula: `{Slack: ID} = '${slackUserId}'`,
       })
       .all()
-    if (matchingUserRecords.length != 1) {
+    if (matchingUserRecords.length !== 1) {
       res.status(400).send('Invalid number of user records matching given ID.')
       return
     }


### PR DESCRIPTION
Viz [PD-8](https://cesko-digital.atlassian.net/browse/PD-8?atlOrigin=eyJpIjoiMmY3Mjk1YmVjMTI1NGZhYTk0NmU3NzA4ZWMyODE5ZjEiLCJwIjoiaiJ9). Po mergnutí se nám myslím rozpadne [stránka Show & Tell](https://cesko.digital/show-and-tell) – asi bych to dočasně ignoroval a následně ji rovnou upravil pro Portál dobrovolníka? Případně z ní můžeme sundat ten odkaz _Chci to do kalendáře_.

Pro identifikaci uživatele se zatím používá Slack ID, ale následně můžeme snadno přepsat na nějaké neutrální UUID, je to triviální změna. (Kterou nedělám rovnou, protože je ještě potřeba dořešit vznik toho UUID v tabulce Volunteers.)