### PR TITLE
Eliminace nadbytečných varování během buildu, PD-179

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "cy:start": "USE_MOCKS=true yarn develop",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
-    "cy:ci": "start-server-and-test cy:start http://localhost:8000 cy:run"
+    "cy:ci": "start-server-and-test cy:start http://localhost:8000 cy:run",
+    "postinstall": "rm -rf node_modules/babel-plugin-lodash/node_modules/lodash"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.6",


### PR DESCRIPTION
Viz [PD-179](https://cesko-digital.atlassian.net/browse/PD-179). TLDR: Po upgradu na Gatsby 3 nám Webpack chrlí do konzole miliardu řádků o konfliktu někde v modulu lodash. Moc tomu nerozumím, googlování příliš nepomohlo, nakonec jsem hackem (`yarn postinstall`) odstranil duplicitní instalaci modulu a je klid. Není to řešení, ale je to pokrok.™ Lepší než mít nerelevantní bordel v logu, ne?

PS. Featuring `rm -rf` kdesi v `node_modules`. What could possibly go wrong? 😇 