### PR TITLE
fix: generování nepodporovaných EN stránek

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,16 @@
 require('dotenv').config()
 
+const subPagePaths = [
+  'partners',
+  'portal-dobrovolnika',
+  'projekty',
+  'roles',
+  'rsvp',
+  'show-and-tell',
+  'events',
+  '404',
+]
+
 module.exports = {
   siteMetadata: {},
   plugins: [
@@ -55,12 +66,11 @@ module.exports = {
         languages: [`cs`, 'en'],
         defaultLanguage: `cs`,
         redirect: false,
-        pages: [
-          {
-            matchPath: '/projekty/:uid',
-            languages: ['cs'],
-          },
-        ],
+        pages: subPagePaths.map((path) => ({
+          matchPath: `/:lang?/${path}/:uid?`,
+          getLanguageFromPath: true,
+          languages: ['cs'],
+        })),
       },
     },
 

--- a/src/generated/graphql-types.ts
+++ b/src/generated/graphql-types.ts
@@ -381,6 +381,7 @@ export type SitePluginPluginOptions = {
 export type SitePluginPluginOptionsPages = {
   __typename?: 'SitePluginPluginOptionsPages'
   matchPath: Maybe<Scalars['String']>
+  getLanguageFromPath: Maybe<Scalars['Boolean']>
   languages: Maybe<Array<Maybe<Scalars['String']>>>
 }
 
@@ -2616,6 +2617,7 @@ export type SitePluginPluginOptionsPagesFilterListInput = {
 
 export type SitePluginPluginOptionsPagesFilterInput = {
   matchPath: Maybe<StringQueryOperatorInput>
+  getLanguageFromPath: Maybe<BooleanQueryOperatorInput>
   languages: Maybe<StringQueryOperatorInput>
 }
 
@@ -2844,6 +2846,7 @@ export enum SitePageFieldsEnum {
   pluginCreator___pluginOptions___redirect = 'pluginCreator___pluginOptions___redirect',
   pluginCreator___pluginOptions___pages = 'pluginCreator___pluginOptions___pages',
   pluginCreator___pluginOptions___pages___matchPath = 'pluginCreator___pluginOptions___pages___matchPath',
+  pluginCreator___pluginOptions___pages___getLanguageFromPath = 'pluginCreator___pluginOptions___pages___getLanguageFromPath',
   pluginCreator___pluginOptions___pages___languages = 'pluginCreator___pluginOptions___pages___languages',
   pluginCreator___pluginOptions___airtableApiKey = 'pluginCreator___pluginOptions___airtableApiKey',
   pluginCreator___pluginOptions___airtableBaseUrl = 'pluginCreator___pluginOptions___airtableBaseUrl',
@@ -3052,6 +3055,7 @@ export enum SitePluginFieldsEnum {
   pluginOptions___redirect = 'pluginOptions___redirect',
   pluginOptions___pages = 'pluginOptions___pages',
   pluginOptions___pages___matchPath = 'pluginOptions___pages___matchPath',
+  pluginOptions___pages___getLanguageFromPath = 'pluginOptions___pages___getLanguageFromPath',
   pluginOptions___pages___languages = 'pluginOptions___pages___languages',
   pluginOptions___airtableApiKey = 'pluginOptions___airtableApiKey',
   pluginOptions___airtableBaseUrl = 'pluginOptions___airtableBaseUrl',


### PR DESCRIPTION
Opravuje generování nepodporovaných EN stránek. 

Checklist pro nové změny:

- [x] Kód je v souladu s [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] Veškerá logika má jednoduché pokrytí unit testy
- [x] Změny byly krátce otestovány v Chrome, Safari, případně dalších prohlížečích
- [x] Git log neboli historie commitů je čistá (rozdělení do více commitů je možné pokud se jedná o odlišný kontext změn, např. nutný refactoring něčeho jiného)
