### PR TITLE
Odkaz na YouTube v patičce

### DIFF
--- a/locale/cs/translation.json
+++ b/locale/cs/translation.json
@@ -41,6 +41,7 @@
           "github": "GitHub",
           "linkedin": "LinkedIn",
           "slack": "Slack",
+          "youtube": "YouTube",
           "title": "Online",
           "twitter": "Twitter"
         },

--- a/src/components/layout/footer/index.tsx
+++ b/src/components/layout/footer/index.tsx
@@ -32,8 +32,8 @@ const Footer: React.FC = () => {
       url: 'https://github.com/cesko-digital',
     },
     {
-      name: t('components.sections.footer.online.slack'),
-      url: LINKS.joinUs,
+      name: t('components.sections.footer.online.youtube'),
+      url: 'https://www.youtube.com/channel/UCYMZxCNq_IWI8URpcx2sBwg',
     },
   ]
 


### PR DESCRIPTION
Tenhle PR nahrazuje odkaz na Slack v patičce odkazem na YouTube. Odkazovat na Slack z patičky nedává moc smysl (máme už prominentní CTA v záhlaví webu) a odkaz na YouTube nám chyběl.