### PR TITLE
Add anchors to main sections in the Volunteer portal

### DIFF
--- a/src/components/layout/section/index.tsx
+++ b/src/components/layout/section/index.tsx
@@ -5,6 +5,7 @@ export interface SectionProps {
   children: ReactNode
   backgroundColor?: string
   as?: string
+  id?: string
 }
 
 interface StyledProps extends SectionProps {

--- a/src/page-components/portal-dobrovolnika/index.tsx
+++ b/src/page-components/portal-dobrovolnika/index.tsx
@@ -69,7 +69,7 @@ const PortalDobrovolnika: React.FC<PortalDobrovolnikaProps> = (props) => {
           </ButtonWrapper>
         </SectionContent>
       </Section>
-      <Section>
+      <Section id="section-cedu">
         <SectionContent>
           <S.CategoryHeader>
             <S.Title>Vzdělávání – č.edu</S.Title>
@@ -99,7 +99,7 @@ const PortalDobrovolnika: React.FC<PortalDobrovolnikaProps> = (props) => {
           </S.Container>
         </SectionContent>
       </Section>
-      <Section>
+      <Section id="section-events">
         <SectionContent>
           <S.CategoryHeader>
             <S.Title>Nejbližší akce</S.Title>


### PR DESCRIPTION
People want to link to various sections directly. In the long term we want to have separate pages for the sections (such as we already have [for opportunities](https://cesko.digital/opportunities/)), but let’s create this as a workaround until then.