### PR TITLE
Lepší dekódování dat z Airtable

### DIFF
--- a/lib/airtable-import.ts
+++ b/lib/airtable-import.ts
@@ -36,6 +36,7 @@ async function getAllRecords<T>(args: {
   });
 
   const base = new Airtable({ apiKey: args.apiKey }).base(args.baseId);
+  const verbose = process.env.VERBOSE_LOG;
   const table = base(args.tableName);
   const response = await table
     .select({ view: args.viewName, maxRecords: 100 /* TBD */ })
@@ -48,8 +49,10 @@ async function getAllRecords<T>(args: {
     try {
       parsedRecords.push(args.decoder(mergeAirtableRecord(record)));
     } catch (e) {
-      console.error(
-        `Parse error for record #${index} in table ${args.tableName}: ${e}`
+      console.warn(
+        verbose
+          ? `Parse error for record #${index} in table ${args.tableName}: ${e}`
+          : `Parse error for record #${index} in table ${args.tableName}, skipping (set VERBOSE_LOG to see more).`
       );
     }
   });

--- a/lib/decoding.test.ts
+++ b/lib/decoding.test.ts
@@ -1,14 +1,14 @@
 import {
-  parsePortalEvent,
-  parsePortalOpportunity,
-  parsePortalProject,
-  parsePortalUser,
-} from "./airtable-import";
+  decodeEvent,
+  decodeOpportunity,
+  decodeProject,
+  decodeUser,
+} from "./portal-types";
 
-test("Import portal project from Airtable", () => {
-  const data = {
-    id: "rec4KOruzwIFU8ieR",
-    fields: {
+test("Decode portal project", () => {
+  expect(
+    decodeProject({
+      id: "rec4KOruzwIFU8ieR",
       csSlug: "loono",
       csName: "Loono – průvodce prevencí",
       tags: ["recVa4LnmzmtfoYTg"],
@@ -27,10 +27,8 @@ test("Import portal project from Airtable", () => {
         "rec0ABdJtGIK9AeCB",
       ],
       slackChannelName: "inkub-loono_pruvodce_prevenci",
-    },
-    createdTime: "2021-04-08T14:09:31.000Z",
-  };
-  expect(parsePortalProject(data)).toEqual({
+    })
+  ).toEqual({
     id: "rec4KOruzwIFU8ieR",
     name: "Loono – průvodce prevencí",
     slug: "loono",
@@ -60,20 +58,16 @@ test("Import portal project from Airtable", () => {
   });
 });
 
-test("Import portal user from Airtable", () => {
-  const data = {
-    id: "recA5nftMpxJmwpr4",
-    fields: {
+test("Decode portal user", () => {
+  expect(
+    decodeUser({
+      id: "recA5nftMpxJmwpr4",
       email: "zoul@cesko.digital",
       profilePictureUrl:
         "https://data.cesko.digital/people/tomas-znamenacek.jpg",
       name: "Tomáš Znamenáček",
-      company: "Česko.Digital",
-      Events: ["recL6LSVKhgH81MBJ"],
-    },
-    createdTime: "2021-06-14T12:38:43.000Z",
-  };
-  expect(parsePortalUser(data)).toEqual({
+    })
+  ).toEqual({
     id: "recA5nftMpxJmwpr4",
     name: "Tomáš Znamenáček",
     profilePictureUrl: "https://data.cesko.digital/people/tomas-znamenacek.jpg",
@@ -81,10 +75,10 @@ test("Import portal user from Airtable", () => {
   });
 });
 
-test("Import portal event from Airtable", () => {
-  const data = {
-    id: "rec9ujcN8HSkE0hgh",
-    fields: {
+test("Decode portal event", () => {
+  expect(
+    decodeEvent({
+      "id": "rec9ujcN8HSkE0hgh",
       "Live URL": "https://cesko.digital/show-and-tell",
       "End Time": "2021-06-24T18:00:00.000Z",
       "RSVP URL": "https://cesko.digital/rsvp",
@@ -102,10 +96,8 @@ test("Import portal event from Airtable", () => {
       "Competence Map": ["dev:100", "marketing:100"],
       "RSVP Deadline": "2021-06-24T17:00:00.000Z",
       "Start Time": "2021-06-24T17:00:00.000Z",
-    },
-    createdTime: "2021-06-03T16:09:12.000Z",
-  };
-  expect(parsePortalEvent(data)).toEqual({
+    })
+  ).toEqual({
     id: "rec9ujcN8HSkE0hgh",
     name: "Show & Tell #2",
     summary: "Živé vysílání bla bla bla…",
@@ -122,10 +114,10 @@ test("Import portal event from Airtable", () => {
   });
 });
 
-test("Parse portal opportunity from Airtable", () => {
-  const data = {
-    id: "reclKrwSllzgEWOnl",
-    fields: {
+test("Decode portal opportunity", () => {
+  expect(
+    decodeOpportunity({
+      "id": "reclKrwSllzgEWOnl",
       "Name": "Frontend developer - React (PWA)",
       "Project": ["recSci1ztMeeakzg2"],
       "Owner": ["rec0ABdJtGIK9AeCB"],
@@ -138,10 +130,8 @@ test("Parse portal opportunity from Airtable", () => {
       "Junior Friendly": true,
       "Skills": ["Dev"],
       "Created Time": "2021-09-02T17:20:26.000Z",
-    },
-    createdTime: "2021-09-02T17:20:26.000Z",
-  };
-  expect(parsePortalOpportunity(data)).toEqual({
+    })
+  ).toEqual({
     id: "reclKrwSllzgEWOnl",
     name: "Frontend developer - React (PWA)",
     slug: "reclKrwSllzgEWOnl",

--- a/lib/decoding.ts
+++ b/lib/decoding.ts
@@ -1,0 +1,32 @@
+import { MarkdownString } from "./utils";
+import { DecoderFunction, Pojo, string } from "typescript-json-decoder";
+
+/** Decode a string, returning it as a `MarkdownString` */
+export const markdown = (value: Pojo): MarkdownString => ({
+  source: string(value),
+});
+
+/** Decode an array of items, returing the first item found */
+export const takeFirst = <T>(decoder: DecoderFunction<T[]>) => {
+  return (value: Pojo) => {
+    const array = decoder(value);
+    if (array.length == 0) {
+      throw "TBD";
+    }
+    return array[0];
+  };
+};
+
+/** Try a decoder and return a default value in case it fails */
+export const withDefault = <T>(
+  decoder: DecoderFunction<T>,
+  defaultValue: T
+) => {
+  return (value: Pojo) => {
+    try {
+      return decoder(value);
+    } catch (_) {
+      return defaultValue;
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sharp": "^0.29.3",
-    "styled-components": "^5.3.3"
+    "styled-components": "^5.3.3",
+    "typescript-json-decoder": "^1.0.4"
   },
   "devDependencies": {
     "@babel/core": "7",

--- a/pages/partners.tsx
+++ b/pages/partners.tsx
@@ -9,6 +9,7 @@ import BecomePartner from "components/partners/sections/become-partner";
 import { Layout, Section, SectionContent } from "components/layout";
 import * as S from "components/partners/styles";
 import Tabs from "components/tabs";
+import { prepareToSerialize } from "lib/utils";
 
 type PageProps = {
   partners: PortalPartner[];
@@ -64,10 +65,11 @@ const Page: NextPage<PageProps> = ({ partners }) => {
 
 export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
   const apiKey = process.env.AIRTABLE_API_KEY as string;
+  const partners = await getAllPartners(apiKey);
   return {
-    props: {
-      partners: await getAllPartners(apiKey),
-    },
+    props: prepareToSerialize({
+      partners,
+    }),
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5472,6 +5472,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript-json-decoder@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/typescript-json-decoder/-/typescript-json-decoder-1.0.5.tgz#d74adac05312b86f67d8bf74699de8f79ae7d448"
+  integrity sha512-js4PvR7qMCo+ZCAPSLOMTMTfb4ObIzUV/xt7sc0H8xe8JLsp6WIWt39eopUr3LKCmjqwVSLkwhW3cuZ9Amh6ag==
+
 typescript@4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"


### PR DESCRIPTION
Dekódování dat z Airtable bylo maximálně jednoduché, bez jakékoliv podstatnější validace. Tenhle PR přidává chytřejší dekódování dat z Airtable tak, aby bylo jisté (nebo dejme tomu jistější 😀), že hodnoty za běhu opravdu odpovídají deklarovaným typům.

Je to trochu „chytře“ napsané s využitím knihovny [typescript-json-decoder](https://github.com/tskj/typescript-json-decoder), takže uvítám zpětnou vazbu, jestli vám to přijde čitelné a ne moc magické. Základní trik je v tom, že abysme zabránili většímu duplikování kódu, tak se typy objektů (například `PortalProject`, `PortalEvent`, …) automaticky odvodí z jejich Airtable dekodéru. A ten pak během dekódování kontroluje invarianty, například přítomnost povinných polí a podobně. Tím pádem by se nikdy neměla hodnota rozejít s deklarovaným typem – protože kód pro její načtení i její typ vychází z jedné společné deklarace.

Kdyby to nebylo jasné, reklamujte, prosím, napravím.