### PR TITLE
Fix Open Graph metadata (og:image)

### DIFF
--- a/components/layout/seo.tsx
+++ b/components/layout/seo.tsx
@@ -22,7 +22,7 @@ export const Seo: React.FC<SeoProps> = ({
         name="description"
         content={description || strings.metadata.description}
       />
-      <meta name="og:image" content={coverUrl} />
+      <meta property="og:image" content={coverUrl} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:image" content={coverUrl} />
       <link rel="stylesheet" href="/fonts.css" />


### PR DESCRIPTION
Use `meta property="og:image"` instead of `meta name="og:image"` in HTML. See https://ogp.me.