### PR TITLE
Přepnutí popisku projektů na formátovaný sloupec „description“ v DB

### DIFF
--- a/lib/decoding.test.ts
+++ b/lib/decoding.test.ts
@@ -16,7 +16,7 @@ test("Decode portal project", () => {
         "Platforma poskytující veškeré informace o prevenci přehledně a na jednom místě",
       logoUrl: "https://data.cesko.digital/web/projects/loono/logo-loono.jpg",
       coverUrl: "https://data.cesko.digital/web/projects/loono/cover-loono.jpg",
-      csDescription: "Vytvoříme místo!",
+      description: "Vytvoříme místo!",
       csContributeText:
         "Děkujeme všem zapojeným dobrovolníkům i pracovníkům z expertních organizací.",
       url: "https://wiki.cesko.digital/pages/viewpage.action?pageId=1584556",

--- a/lib/portal-types.ts
+++ b/lib/portal-types.ts
@@ -30,7 +30,7 @@ export const decodeProject = record({
   name: field("csName", string),
   slug: field("csSlug", string),
   tagline: field("csTagline", string),
-  description: field("csDescription", markdown),
+  description: markdown,
   url: string,
   contributeText: field("csContributeText", optional(markdown)),
   coverImageUrl: field("coverUrl", string),


### PR DESCRIPTION
Duplikoval jsem v Airtable sloupec `csDescription` pod názvem `description` a zapnul u něj možnost formátování. Podpora Markdownu už na klientovi byla. Po mergnutí:

* [ ] Smazat sloupec `csDescription`
* [ ] Přehodit Airtable Interfaces na sloupec `description`