### PR TITLE
Make the “undefined filtering trick” less visible

### DIFF
--- a/lib/site-data.ts
+++ b/lib/site-data.ts
@@ -40,15 +40,18 @@ async function loadSiteData(): Promise<SiteData> {
 
   const DataSource = useLocalData ? Local : Airtable;
 
-  return {
+  return filterUndefines({
     projects: await DataSource.getAllProjects(),
     opportunities: await DataSource.getAllOpportunities(),
     users: await DataSource.getAllUsers(),
     events: await DataSource.getAllEvents(),
     partners: await DataSource.getAllPartners(),
     videos: await getAllVideos(),
-  };
+  });
 }
+
+// This is a hack, see https://github.com/vercel/next.js/issues/11993
+const filterUndefines = <T>(data: T): T => JSON.parse(JSON.stringify(data));
 
 // TODO: Prune data to only keep relevant objects?
 export const siteData = await loadSiteData();

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,10 +4,6 @@ export type MarkdownString = {
   source: string;
 };
 
-// This is a hack, see https://github.com/vercel/next.js/issues/11993
-export const prepareToSerialize = <T>(data: T): T =>
-  JSON.parse(JSON.stringify(data));
-
 export function isExternalURL(url: string): boolean {
   const lc = url.toLowerCase();
   return (

--- a/pages/cedu/[slug].tsx
+++ b/pages/cedu/[slug].tsx
@@ -1,6 +1,5 @@
 import { NextPage, GetStaticPaths, GetStaticProps } from "next";
 import { PortalVideo } from "lib/cedu";
-import { prepareToSerialize } from "lib/utils";
 import { ParsedUrlQuery } from "querystring";
 import { useRouter } from "next/router";
 import { Layout, Section, SectionContent } from "components/layout";
@@ -94,9 +93,9 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
   const { slug } = context.params!;
   const video = siteData.videos.find((v) => v.slug === slug)!;
   return {
-    props: prepareToSerialize({
+    props: {
       video,
-    }),
+    },
   };
 };
 

--- a/pages/en.tsx
+++ b/pages/en.tsx
@@ -3,7 +3,6 @@ import { PortalPartner } from "lib/portal-types";
 import { Layout, Section, SectionContent } from "components/layout";
 import { ThemeContext } from "styled-components";
 import { useContext } from "react";
-import { prepareToSerialize } from "lib/utils";
 import {
   Hero,
   OurValues,
@@ -51,9 +50,9 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
     p.categories.some((c) => c === "homepage")
   );
   return {
-    props: prepareToSerialize({
+    props: {
       partners: homepagePartners,
-    }),
+    },
   };
 };
 

--- a/pages/events/[slug].tsx
+++ b/pages/events/[slug].tsx
@@ -1,6 +1,5 @@
 import type { NextPage, GetStaticPaths, GetStaticProps } from "next";
 import { PortalEvent, PortalProject, PortalUser } from "lib/portal-types";
-import { prepareToSerialize } from "lib/utils";
 import * as Typography from "components/typography";
 import { Layout, Section, SectionContent } from "components/layout";
 import * as S from "components/event/styles";
@@ -107,7 +106,7 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
   const project = projects.find((p) => p.id === event.projectId)!;
   const owner = users.find((u) => u.id === event.ownerId)!;
   return {
-    props: prepareToSerialize({ event, events, project, owner }),
+    props: { event, events, project, owner },
   };
 };
 

--- a/pages/events/index.tsx
+++ b/pages/events/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage, GetStaticProps } from "next";
 import { PortalEvent } from "lib/portal-types";
-import { prepareToSerialize } from "lib/utils";
 import { siteData } from "lib/site-data";
 
 type PageProps = {
@@ -25,7 +24,7 @@ const Page: NextPage<PageProps> = ({ events }) => {
 export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
   return {
     props: {
-      events: prepareToSerialize(siteData.events),
+      events: siteData.events,
     },
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import { Layout, Section, SectionContent } from "components/layout";
 import { Projects, JoinUs } from "components/sections";
 import { ThemeContext } from "styled-components";
 import { useContext } from "react";
-import { prepareToSerialize } from "lib/utils";
 import { siteData } from "lib/site-data";
 import {
   Hero,
@@ -68,10 +67,10 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
     p.categories.some((c) => c === "homepage")
   );
   return {
-    props: prepareToSerialize({
+    props: {
       projects: siteData.projects,
       partners: homepagePartners,
-    }),
+    },
   };
 };
 

--- a/pages/opportunities/[slug].tsx
+++ b/pages/opportunities/[slug].tsx
@@ -1,6 +1,5 @@
 import type { NextPage, GetStaticPaths, GetStaticProps } from "next";
 import { PortalOpportunity, PortalProject, PortalUser } from "lib/portal-types";
-import { prepareToSerialize } from "lib/utils";
 import { Layout, Section, SectionContent } from "components/layout";
 import { Heading1, BodySmall, Body } from "components/typography";
 import * as S from "components/portal-dobrovolnika/opportunity/styles";
@@ -135,12 +134,12 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
   const { opportunities, projects, users } = siteData;
   const opportunity = opportunities.find((o) => o.slug === slug)!;
   return {
-    props: prepareToSerialize({
+    props: {
       opportunity,
       opportunities: opportunities.filter((o) => o.status === "live"),
       projects,
       users,
-    }),
+    },
   };
 };
 

--- a/pages/opportunities/index.tsx
+++ b/pages/opportunities/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage, GetStaticProps } from "next";
 import { PortalOpportunity, PortalProject } from "lib/portal-types";
-import { prepareToSerialize } from "lib/utils";
 import { Layout, SectionContent, Section } from "components/layout";
 import * as Typography from "components/typography";
 import OpportunityItem from "components/sections/opportunity-overview";
@@ -150,10 +149,10 @@ const OpportunitiesCountSpan = styled.span`
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
   const { opportunities, projects } = siteData;
   return {
-    props: prepareToSerialize({
+    props: {
       opportunities: opportunities.filter((o) => o.status === "live"),
       projects,
-    }),
+    },
   };
 };
 

--- a/pages/partners.tsx
+++ b/pages/partners.tsx
@@ -8,7 +8,6 @@ import BecomePartner from "components/partners/sections/become-partner";
 import { Layout, Section, SectionContent } from "components/layout";
 import * as S from "components/partners/styles";
 import Tabs from "components/tabs";
-import { prepareToSerialize } from "lib/utils";
 import { siteData } from "lib/site-data";
 
 type PageProps = {
@@ -65,9 +64,9 @@ const Page: NextPage<PageProps> = ({ partners }) => {
 
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
   return {
-    props: prepareToSerialize({
+    props: {
       partners: siteData.partners,
-    }),
+    },
   };
 };
 

--- a/pages/portal-dobrovolnika.tsx
+++ b/pages/portal-dobrovolnika.tsx
@@ -6,7 +6,6 @@ import EventCard from "components/portal-dobrovolnika/event-card";
 import OpportunityItem from "components/sections/opportunity-overview";
 import { Button } from "components/buttons";
 import { CardRow } from "components/layout";
-import { prepareToSerialize } from "lib/utils";
 import { Route } from "lib/routing";
 import CeduCard from "components/portal-dobrovolnika/cedu-card";
 import { PortalVideo } from "lib/cedu";
@@ -137,12 +136,12 @@ const CeduSection: React.FC<PageProps> = ({ videos }) => {
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
   const { projects, events, opportunities, videos } = siteData;
   return {
-    props: prepareToSerialize({
+    props: {
       events,
       opportunities,
       videos,
       projects,
-    }),
+    },
   };
 };
 

--- a/pages/projekty/[slug].tsx
+++ b/pages/projekty/[slug].tsx
@@ -5,7 +5,7 @@ import AboutProject from "components/project/about";
 import ProjectCard from "components/project/card";
 import Contribute from "components/project/contribute";
 import { Projects } from "components/sections";
-import { getResizedImgUrl, prepareToSerialize } from "lib/utils";
+import { getResizedImgUrl } from "lib/utils";
 import { PortalProject, PortalUser } from "lib/portal-types";
 import * as S from "components/project/styles";
 import strings from "content/strings.json";
@@ -111,11 +111,11 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
     (id) => users.find((user) => user.id === id)!
   );
   return {
-    props: prepareToSerialize({
+    props: {
       project,
       projects,
       coordinators,
-    }),
+    },
   };
 };
 

--- a/pages/projekty/index.tsx
+++ b/pages/projekty/index.tsx
@@ -3,7 +3,6 @@ import { PortalProject } from "lib/portal-types";
 import { Layout, Section, SectionContent } from "components/layout";
 import { JoinUs } from "components/sections";
 import * as S from "components/project/index-styles";
-import { prepareToSerialize } from "lib/utils";
 import strings from "content/strings.json";
 import { siteData } from "lib/site-data";
 import HighlightedProject from "components/project/highlighted";
@@ -55,9 +54,7 @@ const Page: NextPage<PageProps> = ({ projects }) => {
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
   const projects = siteData.projects.filter((p) => p.state !== "draft");
   return {
-    props: prepareToSerialize({
-      projects,
-    }),
+    props: { projects },
   };
 };
 


### PR DESCRIPTION
Next.js insists on not having explicit undefineds in page data:

https://github.com/vercel/next.js/issues/11993

So we filter them out (just leaving the undefined props out). This change moves the filtering trick to a single one, less visible place.