### PR TITLE
Zobrazení délky trvání akcí

### DIFF
--- a/components/event/event-card/index.tsx
+++ b/components/event/event-card/index.tsx
@@ -4,6 +4,7 @@ import Project from "./project";
 import Garant from "./garant";
 import Info from "./info";
 import { PortalEvent, PortalProject, PortalUser } from "lib/portal-types";
+import { getEventDuration } from "lib/portal-type-utils";
 
 interface EventCardProps {
   event: PortalEvent;
@@ -27,7 +28,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, owner, project }) => {
           minute: "2-digit",
         })}
       />
-      {duration && <Info title="Délka akce" content={`${duration} minut`} />}
+      {duration && <Info title="Délka akce" content={duration} />}
       {event.locationTitle && (
         <Info
           title="Místo konání"
@@ -43,19 +44,5 @@ const EventCard: React.FC<EventCardProps> = ({ event, owner, project }) => {
     </S.Container>
   );
 };
-
-function getEventDuration(event: PortalEvent): number | null {
-  if (event.endTime) {
-    const start = new Date(event.startTime);
-    const end = new Date(event.endTime);
-    const ms = end.getTime() - start.getTime();
-    const minutes = ms / 1000 / 60;
-    const minutesPerDay = 60 * 24;
-    // Do a basic sanity check
-    return minutes > 0 && minutes < minutesPerDay ? minutes : null;
-  } else {
-    return null;
-  }
-}
 
 export default EventCard;

--- a/components/event/event-card/index.tsx
+++ b/components/event/event-card/index.tsx
@@ -12,6 +12,7 @@ interface EventCardProps {
 }
 
 const EventCard: React.FC<EventCardProps> = ({ event, owner, project }) => {
+  const duration = getEventDuration(event);
   return (
     <S.Container>
       <Project project={project} />
@@ -26,6 +27,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, owner, project }) => {
           minute: "2-digit",
         })}
       />
+      {duration && <Info title="Délka akce" content={`${duration} minut`} />}
       {event.locationTitle && (
         <Info
           title="Místo konání"
@@ -41,5 +43,19 @@ const EventCard: React.FC<EventCardProps> = ({ event, owner, project }) => {
     </S.Container>
   );
 };
+
+function getEventDuration(event: PortalEvent): number | null {
+  if (event.endTime) {
+    const start = new Date(event.startTime);
+    const end = new Date(event.endTime);
+    const ms = end.getTime() - start.getTime();
+    const minutes = ms / 1000 / 60;
+    const minutesPerDay = 60 * 24;
+    // Do a basic sanity check
+    return minutes > 0 && minutes < minutesPerDay ? minutes : null;
+  } else {
+    return null;
+  }
+}
 
 export default EventCard;

--- a/components/partners/sections/experts/index.tsx
+++ b/components/partners/sections/experts/index.tsx
@@ -1,9 +1,10 @@
 import { Section, SectionContent } from "components/layout";
 import { Heading2, Heading3 } from "components/typography";
 import LogoList from "components/logo-list";
-import { filterPartnersByCategory, PortalPartner } from "lib/portal-types";
+import { PortalPartner } from "lib/portal-types";
 import * as S from "../../styles";
 import strings from "content/strings.json";
+import { filterPartnersByCategory } from "lib/portal-type-utils";
 
 interface ExpertsPartnersProps {
   partners: readonly PortalPartner[];

--- a/components/partners/sections/financial/index.tsx
+++ b/components/partners/sections/financial/index.tsx
@@ -9,7 +9,8 @@ import BlogCard from "components/cards/blog-card";
 import blogPosts from "content/partner-posts.json";
 import strings from "content/strings.json";
 import { BlogHeader } from "./styles";
-import { filterPartnersByCategory, PortalPartner } from "lib/portal-types";
+import { PortalPartner } from "lib/portal-types";
+import { filterPartnersByCategory } from "lib/portal-type-utils";
 
 interface Props {
   partners: readonly PortalPartner[];

--- a/lib/portal-type-utils.test.ts
+++ b/lib/portal-type-utils.test.ts
@@ -1,0 +1,39 @@
+import { getEventDuration } from "./portal-type-utils";
+
+test("Get event duration", () => {
+  // No result for same dates
+  expect(
+    getEventDuration({
+      startTime: "2022-01-14T14:00:00.00Z",
+      endTime: "2022-01-14T14:00:00.00Z",
+    })
+  ).toBe(null);
+  // No result when end time is missing
+  expect(
+    getEventDuration({
+      startTime: "2022-01-14T14:00:00.00Z",
+      endTime: undefined,
+    })
+  ).toBe(null);
+  // Shorter duration in minutes
+  expect(
+    getEventDuration({
+      startTime: "2022-01-14T14:00:00.00Z",
+      endTime: "2022-01-14T15:00:00.00Z",
+    })
+  ).toBe("60 minut");
+  // Longer duration in hours
+  expect(
+    getEventDuration({
+      startTime: "2022-01-14T14:00:00.00Z",
+      endTime: "2022-01-14T17:00:00.00Z",
+    })
+  ).toBe("3 hodiny");
+  // Longer duration in hours
+  expect(
+    getEventDuration({
+      startTime: "2022-01-14T14:00:00.00Z",
+      endTime: "2022-01-14T19:00:00.00Z",
+    })
+  ).toBe("5 hodin");
+});

--- a/lib/portal-type-utils.ts
+++ b/lib/portal-type-utils.ts
@@ -1,0 +1,46 @@
+import { PortalEvent, PortalPartner } from "./portal-types";
+
+/**
+ * Return a human readable event duration such as “120 minut” or “6 hodin”
+ *
+ * If the duration is outside the expected range, you’ll get `null` instead.
+ */
+export function getEventDuration(
+  event: Pick<PortalEvent, "startTime" | "endTime">
+): string | null {
+  if (!event.endTime) {
+    return null;
+  }
+
+  const start = new Date(event.startTime);
+  const end = new Date(event.endTime);
+
+  const minutes = (end.getTime() - start.getTime()) / 1000 / 60;
+
+  if (minutes === 0) {
+    return null;
+  }
+
+  if (minutes > 0 && minutes < 180) {
+    return `${minutes} minut`;
+  }
+
+  const hours = minutes / 60;
+  if (hours <= 4) {
+    return `${hours} hodiny`;
+  } else if (hours <= 48) {
+    return `${hours} hodin`;
+  }
+
+  return null;
+}
+
+export function filterPartnersByCategory(
+  partners: readonly PortalPartner[],
+  category: ArrayElement<PortalPartner["categories"]>
+) {
+  return partners.filter((p) => p.categories.some((c) => c === category));
+}
+
+type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;

--- a/lib/portal-types.ts
+++ b/lib/portal-types.ts
@@ -110,13 +110,3 @@ export const decodePartner = record({
     )
   ),
 });
-
-export function filterPartnersByCategory(
-  partners: readonly PortalPartner[],
-  category: ArrayElement<PortalPartner["categories"]>
-) {
-  return partners.filter((p) => p.categories.some((c) => c === category));
-}
-
-type ArrayElement<ArrayType extends readonly unknown[]> =
-  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;


### PR DESCRIPTION
Fixes #380. Nakonec ukazujeme délku trvání akce místo času konce – to je rozumnější, ne? Můžu dát případně čas konce do titulku, ale to už mně přijde trochu overkill :)