### PR TITLE
Use default user profile when the value is missing in DB

### DIFF
--- a/lib/decoding.test.ts
+++ b/lib/decoding.test.ts
@@ -71,6 +71,19 @@ test("Decode portal user", () => {
     profilePictureUrl: "https://data.cesko.digital/people/tomas-znamenacek.jpg",
     email: "zoul@cesko.digital",
   });
+  // Supply a generic profile picture
+  expect(
+    decodeUser({
+      id: "recA5nftMpxJmwpr4",
+      email: "zoul@cesko.digital",
+      name: "Tomáš Znamenáček",
+    })
+  ).toEqual({
+    id: "recA5nftMpxJmwpr4",
+    name: "Tomáš Znamenáček",
+    profilePictureUrl: "https://data.cesko.digital/people/generic.png",
+    email: "zoul@cesko.digital",
+  });
 });
 
 test("Decode portal event", () => {

--- a/lib/portal-types.ts
+++ b/lib/portal-types.ts
@@ -48,7 +48,10 @@ export const decodeProject = record({
 export const decodeUser = record({
   id: string,
   name: string,
-  profilePictureUrl: string,
+  profilePictureUrl: withDefault(
+    string,
+    "https://data.cesko.digital/people/generic.png"
+  ),
   email: string,
 });
 


### PR DESCRIPTION
Kontext [na Slacku](https://cesko-digital.slack.com/archives/CKJ8F4BT5/p1642405468003600), stručně řečeno chceme, aby chybějící profilovka uživatele neblokovala jeho zveřejnění. Generická profilovka je [toto](https://data.cesko.digital/people/generic.png), chceme ji nějak změnit?