### PR TITLE
Drobné zlepšení seznamu nadcházejících eventů

### DIFF
--- a/lib/portal-type-utils.ts
+++ b/lib/portal-type-utils.ts
@@ -42,5 +42,18 @@ export function filterPartnersByCategory(
   return partners.filter((p) => p.categories.some((c) => c === category));
 }
 
+/** Is event’s start time in the past? */
+export function isEventPast(
+  event: PortalEvent,
+  date: Date = new Date()
+): boolean {
+  const eventDate = new Date(event.startTime);
+  return eventDate.getTime() < date.getTime();
+}
+
+/** Compare events by start time, can be used to sort events by start time */
+export const compareEventsByTime = (a: PortalEvent, b: PortalEvent) =>
+  Date.parse(a.startTime) - Date.parse(b.startTime);
+
 type ArrayElement<ArrayType extends readonly unknown[]> =
   ArrayType extends readonly (infer ElementType)[] ? ElementType : never;

--- a/pages/portal-dobrovolnika.tsx
+++ b/pages/portal-dobrovolnika.tsx
@@ -15,6 +15,7 @@ import {
   PortalProject,
 } from "lib/portal-types";
 import { siteData } from "lib/site-data";
+import { compareEventsByTime, isEventPast } from "lib/portal-type-utils";
 
 interface PageProps {
   opportunities: readonly PortalOpportunity[];
@@ -80,19 +81,18 @@ const OpportunitiesSection: React.FC<PageProps> = ({
 };
 
 const EventsSection: React.FC<PageProps> = ({ events, projects }) => {
-  const compareEventsByTime = (a: PortalEvent, b: PortalEvent) =>
-    Date.parse(b.startTime) - Date.parse(a.startTime); /* TBD */
   const upcomingEvents = [...events]
     .filter((e) => e.status === "live")
+    .filter((e) => !isEventPast(e))
     .sort(compareEventsByTime)
-    .slice(0, 3);
+    .slice(0, 6);
   const eventProject = (e: PortalEvent) =>
     projects.find((p) => p.id === e.projectId)!;
   return (
     <Section id="section-events">
       <SectionContent>
         <S.CategoryHeader>
-          <S.Title>Vybrané akce</S.Title>
+          <S.Title>Nejbližší akce</S.Title>
         </S.CategoryHeader>
         <S.Container>
           <S.CardWrapper>


### PR DESCRIPTION
Ve výběru eventů v Portálu dobrovolníka jsme měli zatím z přelomu roku inverzní chronologické řazení (nejvíc v budoucnosti první) a navíc byl seznam oříznutý na tři eventy. Přehodil jsem řazení na chronologické (nejbližší nejdřív) a zvýšil limit na šest eventů, abychom dočasně obešli fakt, že nám chybí samostatná stránka s přehledem eventů (viz #356).

@lukasnavesnik, je tohle pro tebe dočasně vhodné řešení? [Nasazená verze tady](https://web-i0lkrdt8q-ceskodigital.vercel.app/portal-dobrovolnika). @karmi, je tohle za tebe dočasně OK? Díky!