### PR TITLE
Oprava nechteneho vodorovneho posunu stranky

### DIFF
--- a/components/layout/head.tsx
+++ b/components/layout/head.tsx
@@ -2,17 +2,17 @@
 import Head from "next/head";
 import strings from "content/strings.json";
 
-export interface SeoProps {
+export interface CustomHeadProps {
   description?: string;
   title?: string;
   coverUrl?: string;
 }
 
-export const Seo: React.FC<SeoProps> = ({
+export const CustomHead: React.FC<CustomHeadProps> = ({
   description,
   title,
   coverUrl = "https://data.cesko.digital/web/metadata-cover.png",
-}: SeoProps) => {
+}: CustomHeadProps) => {
   return (
     <Head>
       <title>
@@ -35,4 +35,4 @@ export const Seo: React.FC<SeoProps> = ({
   );
 };
 
-export default Seo;
+export default CustomHead;

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -5,25 +5,25 @@ import Section from "./section";
 import SectionContent from "./section-content";
 import Breadcrumb, { Crumb } from "./breadcrumb";
 import * as S from "./styles";
-import Seo, { SeoProps } from "./seo";
+import CustomHead, { CustomHeadProps } from "./head";
 import HeaderEN from "./header/english";
 
 export interface Props {
   crumbs?: Crumb[];
   children: ReactNode;
-  seo?: SeoProps;
+  head?: CustomHeadProps;
   lang?: "cs" | "en";
 }
 
 const Layout: React.FC<Props> = ({
   crumbs,
   children,
-  seo = {},
+  head: seo = {},
   lang = "cs",
 }: Props) => {
   return (
     <S.Container>
-      <Seo {...seo} />
+      <CustomHead {...seo} />
       {lang === "cs" && <HeaderCS />}
       {lang === "en" && <HeaderEN />}
       {crumbs && (

--- a/pages/cedu/[slug].tsx
+++ b/pages/cedu/[slug].tsx
@@ -38,7 +38,7 @@ const Page: NextPage<PageProps> = ({ video }) => {
         { path: Route.dashboard, label: "Portál dobrovolníka" },
         { label: video.title },
       ]}
-      seo={{
+      head={{
         title: video.title,
         description: video.description,
         coverUrl: video.cover,

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -28,7 +28,7 @@ const PortalDobrovolnika: NextPage<PageProps> = (props) => {
   return (
     <Layout
       crumbs={[{ label: "Portál dobrovolníka" }]}
-      seo={{
+      head={{
         title: "Portál dobrovolníka",
         description: "Tržiště příležitostí, jak se zapojit v Česko.Digital",
         coverUrl: "https://data.cesko.digital/img/bcbb8e4a.png",

--- a/pages/events/[slug].tsx
+++ b/pages/events/[slug].tsx
@@ -38,7 +38,7 @@ const Page: NextPage<PageProps> = (props) => {
         { path: Route.dashboard, label: "Portál dobrovolníka" },
         { label: event.name },
       ]}
-      seo={{
+      head={{
         title: event.name,
         description: event.summary,
         coverUrl: coverImageUrl,

--- a/pages/opportunities/[slug].tsx
+++ b/pages/opportunities/[slug].tsx
@@ -47,7 +47,7 @@ const Page: NextPage<PageProps> = (props) => {
         { path: Route.opportunities, label: "Volné pozice" },
         { label: opportunity.name },
       ]}
-      seo={{
+      head={{
         title: opportunity.name,
         description: opportunity.summary.source, // TODO: We should have a plain text summary and a Markdown description
         coverUrl: coverImageUrl,

--- a/pages/opportunities/index.tsx
+++ b/pages/opportunities/index.tsx
@@ -87,7 +87,7 @@ const Page: NextPage<PageProps> = (props) => {
         { label: "Portál dobrovolníka", path: Route.dashboard },
         { label: "Volné pozice" },
       ]}
-      seo={{
+      head={{
         title: "Volné pozice - Portál dobrovolníka",
         description: "Volné pozice - Portál dobrovolníka",
       }}

--- a/pages/partners.tsx
+++ b/pages/partners.tsx
@@ -44,7 +44,7 @@ const Page: NextPage<PageProps> = ({ partners }) => {
   return (
     <Layout
       crumbs={[{ label: msg.navigation.partners }]}
-      seo={{
+      head={{
         title: msg.metadata.title,
         description: msg.metadata.description,
       }}

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -38,7 +38,7 @@ const ProjectPage: NextPage<PageProps> = (props) => {
         },
         { label: project.name },
       ]}
-      seo={{
+      head={{
         title: project.name,
         description: project.tagline,
         coverUrl: project.coverImageUrl,

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -22,7 +22,7 @@ const Page: NextPage<PageProps> = ({ projects }) => {
   return (
     <Layout
       crumbs={[{ label: msg.navigation.projects }]}
-      seo={{
+      head={{
         title: msg.metadata.title,
         description: msg.metadata.description,
       }}

--- a/public/global.css
+++ b/public/global.css
@@ -1,0 +1,3 @@
+body {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
Opravuje [regresi](https://github.com/cesko-digital/web/blob/4a64cffb19e6a56323504843fa097fd77d206bc9/src/theme/global-style.ts#L12), přidává do souboru `public/global.css`, zároveň refaktoruje komponentu `Seo` na `CustomHead`, což je popisnější.