### PR TITLE
Oprava vodorovného posuvníku, druhé kolo.

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -1,3 +1,3 @@
-body {
+#__next {
   overflow-x: hidden;
 }


### PR DESCRIPTION
Místo nastavení `overflow-x: hidden` pro `body` je nastavuje pro `#__next`, tak jak bylo v původním Gatsby kódu.

Related: #448, #460