### PR TITLE
Zobrazení starších událostí na stránkách projektů

### DIFF
--- a/components/dashboard/event-card/index.tsx
+++ b/components/dashboard/event-card/index.tsx
@@ -9,12 +9,14 @@ import DateTime from "components/datetime";
 interface Props {
   event: PortalEvent;
   project: PortalProject;
+  faded?: boolean;
 }
 
-const EventCard: React.FC<Props> = ({ event, project }) => {
+const EventCard: React.FC<Props> = ({ event, project, faded = false }) => {
   const coverUrl = event.coverImageUrl || project.coverImageUrl;
+  const CardElem = faded ? S.FadedCard : S.Card;
   return (
-    <S.Card>
+    <CardElem>
       <S.Header>
         <S.Cover
           url={getResizedImgUrl(coverUrl, 372)}
@@ -41,7 +43,7 @@ const EventCard: React.FC<Props> = ({ event, project }) => {
         <S.Description>{event.summary}</S.Description>
         <Link to={Route.toEvent(event)}>Detail akce</Link>
       </S.Content>
-    </S.Card>
+    </CardElem>
   );
 };
 

--- a/components/dashboard/event-card/index.tsx
+++ b/components/dashboard/event-card/index.tsx
@@ -9,16 +9,16 @@ import DateTime from "components/datetime";
 interface Props {
   event: PortalEvent;
   project: PortalProject;
-  faded?: boolean;
+  past?: boolean;
 }
 
-const EventCard: React.FC<Props> = ({ event, project, faded = false }) => {
+const EventCard: React.FC<Props> = ({ event, project, past = false }) => {
   const coverUrl = event.coverImageUrl || project.coverImageUrl;
-  const CardElem = faded ? S.FadedCard : S.Card;
+  const CardElem = past ? S.FadedCard : S.Card;
   return (
     <CardElem>
       <S.Header>
-        {faded && (<S.FadedTag>Proběhlo</S.FadedTag>)}
+        {past && (<S.Note>Proběhlo</S.Note>)}
         <S.Cover
           url={getResizedImgUrl(coverUrl, 372)}
           aria-label={`${strings.cards.project.coverAriaLabel} ${event.name}`}

--- a/components/dashboard/event-card/index.tsx
+++ b/components/dashboard/event-card/index.tsx
@@ -5,20 +5,20 @@ import { PortalEvent, PortalProject } from "lib/portal-types";
 import strings from "content/strings.json";
 import { Route } from "lib/routing";
 import DateTime from "components/datetime";
+import { isEventPast } from "lib/portal-type-utils";
 
 interface Props {
   event: PortalEvent;
   project: PortalProject;
-  past?: boolean;
 }
 
-const EventCard: React.FC<Props> = ({ event, project, past = false }) => {
+const EventCard: React.FC<Props> = ({ event, project }) => {
   const coverUrl = event.coverImageUrl || project.coverImageUrl;
-  const CardElem = past ? S.FadedCard : S.Card;
+  const CardElem = isEventPast(event) ? S.FadedCard : S.Card;
   return (
     <CardElem>
       <S.Header>
-        {past && (<S.Note>Proběhlo</S.Note>)}
+        {isEventPast(event) && <S.Note>Proběhlo</S.Note>}
         <S.Cover
           url={getResizedImgUrl(coverUrl, 372)}
           aria-label={`${strings.cards.project.coverAriaLabel} ${event.name}`}

--- a/components/dashboard/event-card/index.tsx
+++ b/components/dashboard/event-card/index.tsx
@@ -18,6 +18,7 @@ const EventCard: React.FC<Props> = ({ event, project, faded = false }) => {
   return (
     <CardElem>
       <S.Header>
+        {faded && (<S.FadedTag>Proběhlo</S.FadedTag>)}
         <S.Cover
           url={getResizedImgUrl(coverUrl, 372)}
           aria-label={`${strings.cards.project.coverAriaLabel} ${event.name}`}

--- a/components/dashboard/event-card/styles.tsx
+++ b/components/dashboard/event-card/styles.tsx
@@ -1,5 +1,5 @@
-import styled from 'styled-components'
-import { Heading3, heading4Styles } from 'components/typography'
+import styled from "styled-components";
+import { Heading3, heading4Styles } from "components/typography";
 
 export const Card = styled.div`
   display: flex;
@@ -12,12 +12,17 @@ export const Card = styled.div`
 
   border-radius: ${({ theme }) => theme.borderRadius.base}px;
   border: 2px solid ${({ theme }) => theme.colors.lightGray};
-`
+`;
+
+export const FadedCard = styled(Card)`
+  filter: grayscale(1);
+  opacity: 0.5;
+`;
 
 export const Header = styled.div`
   position: relative;
   height: 170px;
-`
+`;
 export const CoverWrap = styled.div`
   position: absolute;
   width: 100%;

--- a/components/dashboard/event-card/styles.tsx
+++ b/components/dashboard/event-card/styles.tsx
@@ -20,7 +20,12 @@ export const FadedCard = styled(Card)`
   opacity: 0.5;
 `;
 
-export const FadedTag = styled.div`
+export const Header = styled.div`
+  position: relative;
+  height: 170px;
+`;
+
+export const Note = styled.div`
   font-weight: bold;
   position: absolute;
   bottom: 0px;
@@ -32,10 +37,6 @@ export const FadedTag = styled.div`
   padding: 4px 8px;
 `;
 
-export const Header = styled.div`
-  position: relative;
-  height: 170px;
-`;
 export const CoverWrap = styled.div`
   position: absolute;
   width: 100%;

--- a/components/dashboard/event-card/styles.tsx
+++ b/components/dashboard/event-card/styles.tsx
@@ -30,7 +30,7 @@ export const CoverWrap = styled.div`
   background-color: rgba(0, 0, 255, 0.5);
   border-top-left-radius: ${({ theme }) => theme.borderRadius.base}px;
   border-top-right-radius: ${({ theme }) => theme.borderRadius.base}px;
-`
+`;
 
 export const Cover = styled.div<{ url: string }>`
   position: absolute;
@@ -43,10 +43,10 @@ export const Cover = styled.div<{ url: string }>`
   filter: grayscale(100%);
   border-top-left-radius: ${({ theme }) => theme.borderRadius.base}px;
   border-top-right-radius: ${({ theme }) => theme.borderRadius.base}px;
-`
+`;
 Cover.defaultProps = {
-  role: 'img',
-}
+  role: "img",
+};
 
 export const Logo = styled.div<{ url: string }>`
   position: absolute;
@@ -63,22 +63,22 @@ export const Logo = styled.div<{ url: string }>`
 
   border-radius: 50%;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(8, 8, 50, 0.12);
-`
+`;
 Logo.defaultProps = {
-  role: 'img',
-}
+  role: "img",
+};
 
 export const Content = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   margin: ${({ theme }) => theme.space.lg}px;
-`
+`;
 
 export const Title = styled(Heading3)`
   ${heading4Styles}
   margin-bottom: 9px;
-`
+`;
 
 export const TagList = styled.ul`
   display: flex;
@@ -87,7 +87,7 @@ export const TagList = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
-`
+`;
 
 export const Tag = styled.li`
   background-color: ${({ theme }) => theme.colors.pebble};
@@ -99,18 +99,18 @@ export const Tag = styled.li`
   margin-right: ${({ theme }) => theme.space.small}px;
   margin-bottom: ${({ theme }) => theme.space.small}px;
   padding: ${({ theme }) => theme.space.small}px;
-`
+`;
 
 export const Description = styled.p`
   font-size: ${({ theme }) => theme.fontSizes.base}px;
   flex-grow: 1;
-`
+`;
 
 export const ShortInfoBubbles = styled.div`
   overflow: hidden;
   white-space: nowrap;
   margin-bottom: ${({ theme }) => theme.space.md}px;
-`
+`;
 
 export const ShortInfoBubble = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.small}px;
@@ -123,4 +123,4 @@ export const ShortInfoBubble = styled.div`
   &:last-of-type {
     margin-right: 0;
   }
-`
+`;

--- a/components/dashboard/event-card/styles.tsx
+++ b/components/dashboard/event-card/styles.tsx
@@ -4,6 +4,7 @@ import { Heading3, heading4Styles } from "components/typography";
 export const Card = styled.div`
   display: flex;
   flex-direction: column;
+  position: relative;
 
   min-height: 454px;
   background-color: white;
@@ -17,6 +18,18 @@ export const Card = styled.div`
 export const FadedCard = styled(Card)`
   filter: grayscale(1);
   opacity: 0.5;
+`;
+
+export const FadedTag = styled.div`
+  font-weight: bold;
+  position: absolute;
+  bottom: 0px;
+  right: 0px;
+  z-index: 900;
+  background: rgba(255, 255, 255, 0.2);
+  width: 100%;
+  text-align: right;
+  padding: 4px 8px;
 `;
 
 export const Header = styled.div`

--- a/content/strings.json
+++ b/content/strings.json
@@ -242,7 +242,7 @@
                 "seeAll": "Všechny volné pozice"
             },
             "events": {
-                "title": "Chystané akce",
+                "title": "Vybrané akce",
                 "seeAll": "Všechny chystané akce"
             }
         },

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -121,12 +121,7 @@ const ProjectPage: NextPage<PageProps> = (props) => {
             <S.CardRowWrapper>
               <CardRow>
                 {relatedEvents.map((event) => (
-                  <EventCard
-                    key={event.id}
-                    event={event}
-                    project={project}
-                    past={isEventPast(event)}
-                  />
+                  <EventCard key={event.id} event={event} project={project} />
                 ))}
               </CardRow>
             </S.CardRowWrapper>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -109,7 +109,7 @@ const ProjectPage: NextPage<PageProps> = (props) => {
         </Section>
       )}
 
-      {relatedEvents.length > 0 && (
+      {relatedEvents.length > 0 && relatedEvents.some((e) => !isEventPast(e)) && (
         <Section>
           <SectionContent>
             <S.TitleRow>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -125,7 +125,7 @@ const ProjectPage: NextPage<PageProps> = (props) => {
                     key={event.id}
                     event={event}
                     project={project}
-                    faded={isEventPast(event)}
+                    past={isEventPast(event)}
                   />
                 ))}
               </CardRow>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -109,7 +109,7 @@ const ProjectPage: NextPage<PageProps> = (props) => {
         </Section>
       )}
 
-      {relatedEvents.length > 0 && relatedEvents.some((e) => !isEventPast(e)) && (
+      {relatedEvents.some((e) => !isEventPast(e)) && (
         <Section>
           <SectionContent>
             <S.TitleRow>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -121,7 +121,12 @@ const ProjectPage: NextPage<PageProps> = (props) => {
             <S.CardRowWrapper>
               <CardRow>
                 {relatedEvents.map((event) => (
-                  <EventCard key={event.id} event={event} project={project} />
+                  <EventCard
+                    key={event.id}
+                    event={event}
+                    project={project}
+                    faded={isEventPast(event)}
+                  />
                 ))}
               </CardRow>
             </S.CardRowWrapper>
@@ -202,7 +207,7 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
     .filter((p) => p != project && p.state === "running")
     .slice(0, 3);
   const relatedEvents = events
-    .filter((e) => !isEventPast(e) && e.projectId === project.id)
+    .filter((e) => e.projectId === project.id)
     .slice(0, 3);
   return {
     props: {

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -15,7 +15,7 @@ import { Route } from "lib/routing";
 import { Article } from "lib/related-blog-posts";
 import { BlogCard } from "components/cards";
 import EventCard from "components/dashboard/event-card";
-import { isEventPast } from "lib/portal-type-utils";
+import { compareEventsByTime, isEventPast } from "lib/portal-type-utils";
 import {
   PortalEvent,
   PortalOpportunity,
@@ -208,6 +208,8 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
     .slice(0, 3);
   const relatedEvents = events
     .filter((e) => e.projectId === project.id)
+    .sort(compareEventsByTime)
+    .reverse()
     .slice(0, 3);
   return {
     props: {


### PR DESCRIPTION
Co kdybychom ukazovali na stránkách projektů i starší události, ale s nižší vizuální prioritou? Je z toho hezky vidět „cvrkot“ na projektu a zaplní se tím trochu volné místo v boxu – protože málokterý projekt chystá víc než jednu akci. (Navrhovaná změna je vidět například u Jehlomatu nebo Loona.)

Pokud to chceme, ještě zbývá otázka, jestli ten box zobrazovat i u projektů, které nemají žádnou aktuální akci, tedy celý box by byl šedý (aktuálně vidět na Učíme online).