### PR TITLE
Drop Slack channel names

### DIFF
--- a/components/project/card/index.tsx
+++ b/components/project/card/index.tsx
@@ -17,7 +17,7 @@ const ProjectCard: React.FC<Props> = ({ project, coordinators }) => {
     project.githubUrl ||
     project.trelloUrl ||
     project.jiraUrl ||
-    (project.slackChannelName && project.slackChannelUrl);
+    project.slackChannelUrl;
   return (
     <S.Container>
       {project.coordinatorIds.length > 0 && (
@@ -38,11 +38,11 @@ const ProjectCard: React.FC<Props> = ({ project, coordinators }) => {
           {project.jiraUrl && (
             <SocialMedia logo={JiraIcon} url={project.jiraUrl} name={"Jira"} />
           )}
-          {project.slackChannelName && project.slackChannelUrl && (
+          {project.slackChannelUrl && (
             <SocialMedia
               logo={SlackIcon}
               url={project.slackChannelUrl}
-              name="Slack" // We have quite long channel names, so let’s not use the channel name here
+              name="Slack"
             />
           )}
         </S.Social>

--- a/lib/decoding.test.ts
+++ b/lib/decoding.test.ts
@@ -25,7 +25,6 @@ test("Decode portal project", () => {
         "recwOLHFJUPCoPnLX",
         "rec0ABdJtGIK9AeCB",
       ],
-      slackChannelName: "inkub-loono_pruvodce_prevenci",
     })
   ).toEqual({
     id: "rec4KOruzwIFU8ieR",
@@ -47,7 +46,6 @@ test("Decode portal project", () => {
       "rec0ABdJtGIK9AeCB",
     ],
     slackChannelUrl: "https://cesko-digital.slack.com/archives/C01P6CK0DDY",
-    slackChannelName: "inkub-loono_pruvodce_prevenci",
   });
 });
 

--- a/lib/portal-types.ts
+++ b/lib/portal-types.ts
@@ -42,7 +42,6 @@ export const decodeProject = record({
   jiraUrl: optional(string),
   githubUrl: optional(string),
   slackChannelUrl: optional(string),
-  slackChannelName: optional(string),
 });
 
 export const decodeUser = record({


### PR DESCRIPTION
Na webu je stejně nepoužíváme, zejména protože jsou neskladně dlouhá, tak je vyhoďme komplet.