### PR TITLE
Načítání dat do API z filtrovaných Airtable views

### DIFF
--- a/lib/airtable-import.ts
+++ b/lib/airtable-import.ts
@@ -71,7 +71,7 @@ export const getAllProjects = async () =>
   await getAllRecords({
     baseId: airtableBaseId,
     tableName: "Projects",
-    viewName: "Grid view",
+    viewName: "API view",
     decoder: decodeProject,
   });
 
@@ -79,7 +79,7 @@ export const getAllUsers = async () =>
   await getAllRecords({
     baseId: airtableBaseId,
     tableName: "Volunteers",
-    viewName: "Grid view",
+    viewName: "API view",
     decoder: decodeUser,
   });
 
@@ -87,7 +87,7 @@ export const getAllEvents = async () =>
   await getAllRecords({
     baseId: airtableBaseId,
     tableName: "Events",
-    viewName: "All Events",
+    viewName: "API view",
     decoder: decodeEvent,
   });
 
@@ -95,7 +95,7 @@ export const getAllOpportunities = async () =>
   await getAllRecords({
     baseId: airtableBaseId,
     tableName: "Opportunities",
-    viewName: "Grid view",
+    viewName: "API view",
     decoder: decodeOpportunity,
   });
 


### PR DESCRIPTION
Viz #422. Zavedl jsem do Airtable pár pohledů „API view“, kde jsou filtrovaná data – zejména tam nepouštíme řádky, kde chybí povinná data, a pak ještě zahazujeme nerelevantní data (například dávno minulé eventy). Můžeme nad tím podumat – velmi dobře to dopadlo u eventů, kde zmizelo kolem 40 záznamů, a příležitostí, kde zmizelo 30 záznamů. Velmi pozitivní taky je, že nám z build logu zmizela všechna varování na chyby v parsování dat. Ale je to nějaká složitost navíc.