### PR TITLE
Kešování zmenšených obrázků

### DIFF
--- a/pages/api/resize.ts
+++ b/pages/api/resize.ts
@@ -143,13 +143,8 @@ const handler = async (
     // Attempt to fetch and transform provided image
     const preparedImageData = await prepareImageFromSource(data);
 
-    response.setHeader(
-      "Cache-Control",
-      "max-age=0, s-maxage=60, stale-while-revalidate=60"
-    );
-
+    response.setHeader("Cache-Control", "max-age=86400, s-maxage=86400");
     response.setHeader("Content-Type", preparedImageData.contentType);
-
     response.status(200).send(preparedImageData.processedImage);
   } catch (e) {
     const [code, msg] =


### PR DESCRIPTION
Closes #415. V tom starém kódu jsme měli hrozně krátkou životnost zmenšovaných obrázků, takže se stahovaly furt dokola. Osobně bych nejradši měl ty obrázky immutable, tedy pojmenované podle heše obsahu, aby mohly mít nekonečnou životnost, ale prozačátek aspoň prodlužme trvanlivost těch zmenšovaných obrázků na jeden den? Výhoda: častější návštěvníci budou mít obrázky v keši. Nevýhoda: pokud nějaký obrázek změníme na původním místě, může trvat až den, než se změna projeví u všech.