### PR TITLE
Plausible Analytics + nový účet GTM

### DIFF
--- a/components/layout/head.tsx
+++ b/components/layout/head.tsx
@@ -26,6 +26,11 @@ export const CustomHead: React.FC<CustomHeadProps> = ({
         name="description"
         content={description || strings.metadata.description}
       />
+      <script
+        defer
+        data-domain="cesko.digital"
+        src="https://plausible.io/js/plausible.js"
+      ></script>
       <meta property="og:image" content={coverUrl} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:image" content={coverUrl} />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,7 +22,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer', 'GTM-PWGVF79');
+        })(window,document,'script','dataLayer', 'GTM-PRMTS8P');
       `}
       </Script>
       <GlobalStyle />


### PR DESCRIPTION
První část #421 – zavádíme kód pro Plausible Analytics a aktualizujeme ID pro Google Tag Manager. Díky té druhé změně zmizí všechny cookies kromě Google Analytics.