### PR TITLE
Lepší výběr příležitostí na dashboard

### DIFF
--- a/lib/skills.ts
+++ b/lib/skills.ts
@@ -7,6 +7,7 @@ import {
   record,
   string,
 } from "typescript-json-decoder";
+import { unique } from "./utils";
 
 export type Skill = decodeType<typeof decodeSkill>;
 
@@ -52,5 +53,3 @@ export async function loadAllSkills(): Promise<Field[]> {
 }
 
 const decodeSkills = array(decodeSkill);
-
-const unique = <T>(a: T[]) => [...new Set(a)];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -41,3 +41,8 @@ export function shuffleInPlace<T>(array: T[]): T[] {
   }
   return array;
 }
+
+export const unique = <T>(a: T[]) => [...new Set(a)];
+
+export const getRandomElem = <T>(a: T[]) =>
+  a[Math.floor(Math.random() * a.length)];


### PR DESCRIPTION
Aktuálně si ten výběr může snadno monopolizovat poslední zadaný projekt:

![featured](https://user-images.githubusercontent.com/95329/157878175-9efd1aba-2540-4cca-91de-54b2184f07ad.png)

Změnil jsem algoritmus výběru tak, abychom vybrali 3 náhodné projekty a z nich po jedné náhodné příležitosti. Nový výběr se nalosuje při každém přenasazení.