### PR TITLE
Založení uživatelského profilu

### DIFF
--- a/pages/api/registrations.ts
+++ b/pages/api/registrations.ts
@@ -1,6 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
+import { NextApiRequest, NextApiResponse } from "next";
 import Airtable from "airtable";
 
+/** Create a new, unconfirmed user profile */
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
@@ -21,14 +22,16 @@ export default async function handler(
   try {
     const apiKey = process.env.AIRTABLE_API_KEY;
     const base = new Airtable({ apiKey }).base("apppZX1QC3fl1RTBM");
+    const state = "unconfirmed";
     const registration = {
       fields: {
-        Name: name,
-        Email: email,
-        Skills: skills,
+        name,
+        email,
+        skills,
+        state,
       },
     };
-    await base("Registrations").create([registration]);
+    await base("Profiles 2.0").create([registration]);
     response.status(201).send("Registration created.");
   } catch (e) {
     response.status(500).send("Sorry :(");

--- a/pages/api/registrations.ts
+++ b/pages/api/registrations.ts
@@ -6,6 +6,7 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
+  // Validate input
   const { name, email, skills } = request.body;
   if (!name) {
     response.status(400).send("Missing “name” param.");
@@ -21,7 +22,23 @@ export default async function handler(
   }
   try {
     const apiKey = process.env.AIRTABLE_API_KEY;
-    const base = new Airtable({ apiKey }).base("apppZX1QC3fl1RTBM");
+    const base = new Airtable({ apiKey }).base("apppZX1QC3fl1RTBM")(
+      "Profiles 2.0"
+    );
+
+    // Make sure the email doesn’t exist already
+    const previousRecords = await base
+      .select({
+        filterByFormula: `{email} = "${email}"`,
+      })
+      .all();
+    if (previousRecords.length != 0) {
+      const msg = "Email already exists";
+      console.error(msg);
+      response.status(401).send(msg);
+      return;
+    }
+
     const state = "unconfirmed";
     const registration = {
       fields: {
@@ -31,9 +48,10 @@ export default async function handler(
         state,
       },
     };
-    await base("Profiles 2.0").create([registration]);
+    await base.create([registration]);
     response.status(201).send("Registration created.");
   } catch (e) {
+    console.error(e);
     response.status(500).send("Sorry :(");
   }
 }


### PR DESCRIPTION
Součást #538. Tohle je úplná drobnost, pouze jsem přehodil onboarding form na novou tabulku [Profiles 2.0](https://airtable.com/apppZX1QC3fl1RTBM/tblUmjkniqR4PUu5R/viwAHmRmBxdpyjixq?blocks=hide) (přejmenujeme později, až budeme definitivně nasazovat).

A ještě jedna změna – ten endpoint musí být z principu neautentizovaný, takže jsem přidal do DB ještě pole `status` s hodnotami `{unconfirmed, confirmed}`. Nově založené účty přes tenhle endpoint začínají ve stavu `unconfirmed`, může to být libovolný spam. Teprve až později najdeme (a doplníme) příslušné Slack ID spojené s touhle e-mailovou adresou, přehodíme účet na ověřený. (Měla by tedy sedět invarianta `confirmed == (slackId != null)`.) Dovedu si představit, že tenhle výčet stavů pak můžem ještě nějak doplnit (například v souvislosti s mazáním uživatelů.)

Chceme nějak řešit situaci, kdy nám někdo přes tenhle endpoint založí profil s již existující e-mailovou adresou, ať už potvrzenou, či nepotvrzenou? Vnímám jako bezpečnější to odmítnout.