### PR TITLE
API pro správu uživatelského profilu

### DIFF
--- a/lib/airtable-request.ts
+++ b/lib/airtable-request.ts
@@ -1,0 +1,71 @@
+import { FieldSet, Record, Table } from "airtable";
+import { QueryParams } from "airtable/lib/query_params";
+
+export type SimpleRecord<TFields extends FieldSet> = Pick<
+  Record<TFields>,
+  "id" | "fields"
+>;
+
+export type SimpleRecords<TFields extends FieldSet> = ReadonlyArray<
+  SimpleRecord<TFields>
+>;
+
+export interface BaseRequest<Result> {
+  method: string;
+  decodeResponse: (args: any) => Result;
+}
+
+export interface FindRequest<Result, TFields extends FieldSet>
+  extends BaseRequest<Result> {
+  method: "FIND";
+  recordId: string;
+  decodeResponse: (record: SimpleRecord<TFields>) => Result;
+}
+
+export interface SelectRequest<Result, TFields extends FieldSet>
+  extends BaseRequest<Result> {
+  method: "SELECT";
+  params: QueryParams<TFields>;
+  decodeResponse: (records: SimpleRecords<TFields>) => Result;
+}
+
+export interface UpdateRequest<Result, TFields extends FieldSet>
+  extends BaseRequest<Result> {
+  method: "UPDATE";
+  recordId: string;
+  recordFields: Partial<TFields>;
+  decodeResponse: (record: SimpleRecord<TFields>) => Result;
+}
+
+export type Request<Result, TFields extends FieldSet = {}> =
+  | FindRequest<Result, TFields>
+  | SelectRequest<Result, TFields>
+  | UpdateRequest<Result, TFields>;
+
+export async function send<Result, TFields extends FieldSet>(
+  table: Table<TFields>,
+  request: Request<Result, TFields>
+): Promise<Result> {
+  switch (request.method) {
+    case "FIND":
+      const foundRecord = await table.find(request.recordId);
+      return request.decodeResponse(foundRecord);
+    case "SELECT":
+      const matchingRecords = await table.select(request.params).all();
+      return request.decodeResponse(matchingRecords);
+    case "UPDATE":
+      const updatedRecord = await table.update(
+        request.recordId,
+        request.recordFields
+      );
+      return request.decodeResponse(updatedRecord);
+  }
+}
+
+/** This is a simple hack that makes the database ID available in record fields */
+export const mergeFields = <TFields extends FieldSet>(
+  record: SimpleRecord<TFields>
+) => ({
+  id: record.id,
+  ...record.fields,
+});

--- a/lib/user-profile.test.ts
+++ b/lib/user-profile.test.ts
@@ -1,0 +1,41 @@
+import { getUserProfile, UserProfile } from "./user-profile";
+
+test("Encode request", () => {
+  expect(getUserProfile("slack-id")).toEqual({
+    method: "SELECT",
+    params: {
+      filterByFormula: `{slackId} = "slack-id"`,
+    },
+    decodeResponse: expect.any(Function),
+  });
+});
+
+test("Decode response", () => {
+  const decoder = getUserProfile("slack-id").decodeResponse;
+  expect(decoder([])).toBeUndefined();
+  expect(
+    decoder([
+      {
+        id: "uisoh7Ei",
+        fields: {
+          name: "John Smith",
+          email: "john@smith.name",
+          skills: ["foo", "bar"],
+          slackId: "slack-id",
+          state: "confirmed",
+          createdAt: "2022-03-23T08:31:54.500Z",
+          lastModifiedAt: "2022-03-23T08:31:54.500Z",
+        },
+      },
+    ])
+  ).toEqual<UserProfile>({
+    id: "uisoh7Ei",
+    name: "John Smith",
+    email: "john@smith.name",
+    skills: ["foo", "bar"],
+    slackId: "slack-id",
+    state: "confirmed",
+    createdAt: "2022-03-23T08:31:54.500Z",
+    lastModifiedAt: "2022-03-23T08:31:54.500Z",
+  });
+});

--- a/lib/user-profile.ts
+++ b/lib/user-profile.ts
@@ -1,3 +1,6 @@
+import { FieldSet } from "airtable";
+import { mergeFields, SelectRequest, UpdateRequest } from "./airtable-request";
+import { AirtableBase } from "airtable/lib/airtable_base";
 import {
   array,
   decodeType,
@@ -6,8 +9,27 @@ import {
   string,
   union,
 } from "typescript-json-decoder";
+import { assert } from "console";
 
+/** The Airtable schema of the user profile table */
+export interface Schema extends FieldSet {
+  name: string;
+  email: string;
+  skills: ReadonlyArray<string>;
+  slackId: string;
+  state: string;
+  createdAt: string;
+  lastModifiedAt: string;
+}
+
+/** Get user profile table from given Airtable base */
+export const userProfileTable = (base: AirtableBase) =>
+  base<Schema>("Profiles 2.0");
+
+/** A user profile type */
 export type UserProfile = decodeType<typeof decodeUserProfile>;
+
+/** Decode `UserProfile` from an incoming object (usually an Airtable record) */
 export const decodeUserProfile = record({
   id: string,
   name: string,
@@ -18,3 +40,40 @@ export const decodeUserProfile = record({
   createdAt: string,
   lastModifiedAt: string,
 });
+
+/** Get user profile with given Slack ID */
+export function getUserProfile(
+  slackId: string
+): SelectRequest<UserProfile | undefined, Schema> {
+  return {
+    method: "SELECT",
+    params: {
+      filterByFormula: `{slackId} = "${slackId}"`,
+    },
+    decodeResponse: (records) => {
+      assert(
+        records.length <= 1,
+        `Multiple user rows with same Slack ID “${slackId}” exist.`
+      );
+      if (records.length > 0) {
+        const fields = mergeFields(records[0]) as any;
+        return decodeUserProfile(fields);
+      } else {
+        return undefined;
+      }
+    },
+  };
+}
+
+/** Update user profile with given Airtable record ID */
+export function updateUserProfile(
+  recordId: string,
+  fields: Pick<UserProfile, "name" | "email" | "skills">
+): UpdateRequest<UserProfile, Schema> {
+  return {
+    method: "UPDATE",
+    recordId,
+    recordFields: fields,
+    decodeResponse: (record) => decodeUserProfile(mergeFields(record) as any),
+  };
+}

--- a/lib/user-profile.ts
+++ b/lib/user-profile.ts
@@ -1,0 +1,20 @@
+import {
+  array,
+  decodeType,
+  optional,
+  record,
+  string,
+  union,
+} from "typescript-json-decoder";
+
+export type UserProfile = decodeType<typeof decodeUserProfile>;
+export const decodeUserProfile = record({
+  id: string,
+  name: string,
+  email: string,
+  skills: array(string),
+  slackId: optional(string),
+  state: union("unconfirmed", "confirmed"),
+  createdAt: string,
+  lastModifiedAt: string,
+});

--- a/pages/api/protected/me.ts
+++ b/pages/api/protected/me.ts
@@ -1,0 +1,67 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getToken } from "next-auth/jwt";
+import { decodeUserProfile } from "lib/user-profile";
+import Airtable from "airtable";
+
+/**
+ * Retrieve or update user profile
+ *
+ * BEWARE: All we can trust for user identification is the JWT
+ * session token. Anything else may be spoofed by the user.
+ */
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  const token = await getToken({ req: request });
+  if (!token) {
+    response.status(401).send("Auth token missing");
+    return;
+  }
+
+  const apiKey = process.env.AIRTABLE_API_KEY;
+  const base = new Airtable({ apiKey }).base("apppZX1QC3fl1RTBM")(
+    "Profiles 2.0"
+  );
+
+  const { method } = request;
+
+  try {
+    switch (method) {
+      case "GET":
+        const userRecords = await base
+          .select({
+            filterByFormula: `{slackId} = "${token.sub}"`,
+          })
+          .all();
+        if (userRecords.length === 0) {
+          response.status(404).send("User not found");
+          return;
+        }
+        const record = userRecords[0];
+        const profile = decodeUserProfile({ id: record.id, ...record.fields });
+        response.setHeader("Content-Type", "application/json");
+        response.status(200).send(JSON.stringify(profile, null, 2));
+        break;
+      case "PATCH":
+        const existingRecords = await base
+          .select({ filterByFormula: `{slackId} = "${token.sub}"` })
+          .all();
+        if (existingRecords.length === 0) {
+          response.status(404).send("User with given slackId not found");
+          return;
+        }
+        const databaseId = existingRecords[0].id;
+        const { name, email, skills } = request.body;
+        await base.update(databaseId, { name, email, skills });
+        response.status(200).send("Updated");
+        break;
+      default:
+        response.setHeader("Allow", ["GET", "PATCH"]);
+        response.status(405).end(`Method ${method} Not Allowed`);
+    }
+  } catch (e) {
+    console.error(e);
+    response.status(500).send("Internal error, sorry!");
+  }
+}


### PR DESCRIPTION
Součást #538. Přidal jsem endpoint `/api/protected/me`. Je autentizovaný přes JWT token a podporuje metody `GET` (vrátí profil přihlášeného uživatele) a `PATCH` (uloží změny ve jménu, mailu nebo dovednostech). Odchylky od zadání:

* Zvolil jsem název `me` místo `profile`, podle mě to líp vystihuje, že nejde o obecnou správu profilů, ale pracujeme pouze s tím aktuálně přihlášeným.
* Místo `PUT` jsem vybral `PATCH`, protože většinu props toho objektu nejde měnit, například `slackId`, `state` nebo `createdAt`. Tak mně `PATCH` přijde výstižnější, člověk u něj očekává nějakou podmnožinu props.

Funguje to pouze pro potvrzené profily, tj. ty s vyplněným `slackId`. Dá se to udělat i tak, aby se případně profil našel podle mailu, ale spíš to chce nejdřív domyslet proces, kterým dojde k potvrzení účtu.

Celkově z toho vůbec nejsem šťastný, je to taková netestovatelná hromada bordelu slepená izolepou 💩 Navrhuju to zatím akceptovat, ať se pohnem dopředu, ale budu průběžně přemýšlet nad lepší prací s Airtable, zejména aby endpointy nemusely dělat tolik manuální práce a dalo se to aspoň trochu otestovat. (Ideální by bylo, kdyby endpoint sloužil pouze jako jednoduchý wrapper nějaké čisté funkce, která dělá transformaci mezi daty od/pro uživatele a Airtable.)

Zápis možno testovat takto:

```bash
curl -H "Authorization: Bearer <token>" -X PATCH -H 'Content-Type: application/json' --data '{"name":"foo"}' https://…/api/protected/me
```