### PR TITLE
Oprava responzivnosti volných pozic 

### DIFF
--- a/components/sections/opportunity-overview/index.tsx
+++ b/components/sections/opportunity-overview/index.tsx
@@ -26,19 +26,21 @@ const OpportunityItem: React.FC<Props> = ({ opportunity, relatedProject }) => {
         </div>
         {relatedProject && (
           <S.OpportunityRightWrapper>
-            {relatedProject.state !== "draft" &&
-              relatedProject.state !== "internal" && (
-                <Link href={Route.toProject(relatedProject)}>
-                  <a>
-                    <Body>{relatedProject.name}</Body>
-                  </a>
-                </Link>
+            <S.OpportunityRightContent>
+              {relatedProject.state !== "draft" &&
+                relatedProject.state !== "internal" && (
+                  <Link href={Route.toProject(relatedProject)}>
+                    <a>
+                      <BodySmall>{relatedProject.name}</BodySmall>
+                    </a>
+                  </Link>
+                )}
+              {(relatedProject.state === "draft" ||
+                relatedProject.state === "internal") && (
+                <BodySmall>{relatedProject.name}</BodySmall>
               )}
-            {(relatedProject.state === "draft" ||
-              relatedProject.state === "internal") && (
-              <Body>{relatedProject.name}</Body>
-            )}
-            <S.OpportunityLogo src={relatedProject.logoUrl} />
+              <S.OpportunityLogo src={relatedProject.logoUrl} />
+            </S.OpportunityRightContent>
           </S.OpportunityRightWrapper>
         )}
       </S.OpportunityWrapper>

--- a/components/sections/opportunity-overview/styles.tsx
+++ b/components/sections/opportunity-overview/styles.tsx
@@ -1,45 +1,75 @@
-import styled from 'styled-components'
-import { heading4Styles } from 'components/typography'
+import styled from "styled-components";
+import { heading4Styles } from "components/typography";
 
 export const Container = styled.div`
   max-width: ${({ theme }) => theme.contentSize}px;
   margin: 0 auto;
-`
+`;
 
 export const OpportunityWrapper = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding: 22px 0;
   border-bottom: 1px solid #f0f0f2;
+  gap: 1rem;
   a {
     text-decoration: none;
   }
-`
+`;
 
 export const OpportunityHeading = styled.div`
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    font-size: ${({ theme }) => theme.fontSizes.base}px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    font-size: ${({ theme }) => theme.fontSizes.small}px;
+  }
+
   ${heading4Styles}
   font-weight: 700;
   color: ${({ theme }) => theme.colors.darkGrey};
-`
+`;
 
 export const OpportunityMetaWrapper = styled.div`
   display: flex;
+  flex-direction: row;
   gap: 12px;
   margin-top: 14px;
-`
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    flex-direction: column;
+  }
+`;
 
 export const OpportunityRightWrapper = styled.div`
   display: flex;
+  justify-content: flex-end;
+`;
+
+export const OpportunityRightContent = styled.div`
+  display: flex;
+  flex-direction: row;
   gap: 24px;
-  text-align: right;
+
   a {
     text-decoration: none;
   }
-`
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    font-size: ${({ theme }) => theme.fontSizes.base}px;
+    flex-direction: column-reverse;
+    align-items: center;
+    text-align: center;
+    gap: 16px;
+    width: 120px;
+  }
+`;
 
 export const OpportunityLogo = styled.img`
   width: 80px;
   height: 80px;
   border-radius: 50%;
   background: gray;
-`
+`;


### PR DESCRIPTION
Součást #358. Opravil jsem responsivnost volných pozic na stránce `opportunities`.

PR obsahuje hlavně tyto úpravy:

- [x] Oprava překrývajích textů pro mobilní zařízení a tablety
- [x] Mobilním/Tabletí zobrazení je kompaktnější
- [x] Pro zobrazení názvu projektu jsem použil `BodySmall` místo `Body` z estetických a responzivních důvodů
...