### PR TITLE
Migrace dat na nové databázové schéma

### DIFF
--- a/bin/migrate-users.ts
+++ b/bin/migrate-users.ts
@@ -1,0 +1,67 @@
+require("dotenv").config({ path: ".env.local" });
+
+import { getAllSlackUsers } from "lib/airtable/slack-user";
+import { getAllVolunteers } from "lib/airtable/volunteers";
+import {
+  createUserProfile,
+  getUserProfileByMail,
+  UserProfile,
+} from "lib/airtable/user-profile";
+
+async function main() {
+  // Download all Volunteers from the legacy table
+  console.log(`Downloading all records from the Volunteers table.`);
+  const volunteers = await getAllVolunteers();
+  console.log(
+    `Successfully downloaded and parsed ${volunteers.length} records.`
+  );
+
+  // Download all Slack Users from the new table
+  console.log(`Downloading all records from the Slack Users table.`);
+  const slackUsers = await getAllSlackUsers();
+  console.log(
+    `Successfully downloaded and parsed ${slackUsers.length} records.`
+  );
+
+  // Now create or update user info in the new User Profiles table
+  // and pair the user profiles to appropriate Slack Users.
+  type User = Pick<
+    UserProfile,
+    "name" | "email" | "skills" | "slackUserRelationId" | "state"
+  >;
+  let userProfiles: User[] = [];
+  console.log("Pairing user data.");
+  for (const slackUser of slackUsers) {
+    const volunteer = volunteers.find(
+      (candidate) => candidate.slackId === slackUser.slackId
+    );
+    if (!volunteer) {
+      console.log(`Volunteer not found for Slack user ${slackUser.slackId}`);
+      continue;
+    }
+    userProfiles.push({
+      email: volunteer.email,
+      name: slackUser.name,
+      skills: volunteer.skillIds,
+      slackUserRelationId: slackUser.id,
+      state: "confirmed",
+    });
+  }
+
+  console.log("Updating the User Profiles table.");
+  for (const profile of userProfiles) {
+    const existingProfile = await getUserProfileByMail(profile.email).catch(
+      () => null
+    );
+    if (!existingProfile) {
+      console.log(`User profile for ${profile.email} not found, creating.`);
+      await createUserProfile(profile);
+    } else {
+      console.log(
+        `User profile for ${profile.email} already exists, skipping.`
+      );
+    }
+  }
+}
+
+main().catch((e) => console.error(e));

--- a/lib/airtable/user-profile.ts
+++ b/lib/airtable/user-profile.ts
@@ -13,6 +13,7 @@ import {
   string,
   union,
 } from "typescript-json-decoder";
+import { unique } from "lib/utils";
 
 /** The Airtable schema of the user profile table */
 export interface Schema extends FieldSet {
@@ -55,7 +56,11 @@ export function encodeUserProfile(
     id: profile.id,
     name: profile.name,
     email: profile.email,
-    skills: profile.skills,
+    // This is weird but apparently there might be duplicate skill
+    // IDs in records we get from the API, and then we get an error
+    // trying to write the values back in. So we make sure the values
+    // are unique.
+    skills: profile.skills ? unique(profile.skills) : undefined,
     state: profile.state,
     slackUser: profile.slackUserRelationId
       ? [profile.slackUserRelationId]

--- a/lib/airtable/user-profile.ts
+++ b/lib/airtable/user-profile.ts
@@ -112,10 +112,10 @@ export async function updateUserProfile(
 
 /** Create new user profile */
 export async function createUserProfile(
-  profile: Pick<UserProfile, "name" | "email" | "skills">
+  profile: Pick<UserProfile, "name" | "email" | "skills" | "state">
 ): Promise<UserProfile> {
   return await userProfileTable
-    .create([encodeUserProfile(profile)])
-    .then(unwrapRecords)
-    .then(takeFirst(array(decodeUserProfile)));
+    .create(encodeUserProfile(profile))
+    .then(unwrapRecord)
+    .then(decodeUserProfile);
 }

--- a/lib/airtable/volunteers.ts
+++ b/lib/airtable/volunteers.ts
@@ -1,0 +1,42 @@
+import { FieldSet } from "airtable";
+import { withDefault } from "lib/decoding";
+import { unwrapRecords, volunteerManagementBase } from "./request";
+import {
+  array,
+  decodeType,
+  field,
+  record,
+  string,
+} from "typescript-json-decoder";
+
+/** The Airtable schema of the Volunteers table */
+export interface Schema extends FieldSet {
+  "Slack: E-mail": string;
+  "Slack: ID": string;
+  "Self-reported skills": ReadonlyArray<string>;
+}
+
+/** Volunteers table */
+export const volunteersTable = volunteerManagementBase<Schema>("Volunteers");
+
+/** Volunteer */
+export type Volunteer = decodeType<typeof decodeVolunteer>;
+
+/** Decode `SlackUser` from DB schema */
+export const decodeVolunteer = record({
+  email: field("Slack: E-mail", string),
+  slackId: field("Slack: ID", string),
+  skillIds: field("Self-reported skills", withDefault(array(string), [])),
+});
+
+//
+// API Calls
+//
+
+export async function getAllVolunteers(): Promise<Volunteer[]> {
+  return await volunteersTable
+    .select()
+    .all()
+    .then(unwrapRecords)
+    .then(array(decodeVolunteer));
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest",
     "e2e": "npx playwright test",
     "update-data": "ts-node -r tsconfig-paths/register bin/update-local-data.ts",
-    "sync-users": "ts-node -r tsconfig-paths/register bin/sync-users.ts"
+    "sync-users": "ts-node -r tsconfig-paths/register bin/sync-users.ts",
+    "migrate-users": "ts-node -r tsconfig-paths/register bin/migrate-users.ts"
   },
   "dependencies": {
     "airtable": "^0.11.2",

--- a/pages/api/user_profiles.ts
+++ b/pages/api/user_profiles.ts
@@ -32,6 +32,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
         name,
         email,
         skills,
+        state: "unconfirmed",
       });
       response.status(201).send("User profile created.");
     }


### PR DESCRIPTION
Součást #538, fixes #565. PR přidává skript, který přehrne data ze starší tabulky _Volunteers_ do novějších tabulek _User Profiles_ a _Slack Users_ podle podrobného zadání z ticketu.