### PR TITLE
Jednodušší spouštění pomocných skriptů

### DIFF
--- a/bin/migrate-users.ts
+++ b/bin/migrate-users.ts
@@ -1,4 +1,4 @@
-require("dotenv").config({ path: ".env.local" });
+#!/usr/bin/env ts-node -r tsconfig-paths/register -r dotenv-flow/config
 
 import { getAllSlackUsers } from "lib/airtable/slack-user";
 import { getAllVolunteers } from "lib/airtable/volunteers";

--- a/bin/sync-ecomail-subscribers.ts
+++ b/bin/sync-ecomail-subscribers.ts
@@ -1,4 +1,4 @@
-require("dotenv").config({ path: ".env.local" });
+#!/usr/bin/env ts-node -r tsconfig-paths/register -r dotenv-flow/config
 
 import { getAllUserProfiles } from "lib/airtable/user-profile";
 import { addSubscribers } from "lib/ecomail";

--- a/bin/sync-slack-users.ts
+++ b/bin/sync-slack-users.ts
@@ -1,4 +1,4 @@
-require("dotenv").config({ path: ".env.local" });
+#!/usr/bin/env ts-node -r tsconfig-paths/register -r dotenv-flow/config
 
 import { isDeepStrictEqual } from "util";
 import { getAllWorkspaceUsers, isRegularUser, SlackUser } from "lib/slack/user";

--- a/bin/update-local-data.ts
+++ b/bin/update-local-data.ts
@@ -1,4 +1,6 @@
-import { default as fetch } from "node-fetch";
+#!/usr/bin/env ts-node -r tsconfig-paths/register -r dotenv-flow/config
+
+import fetch from "node-fetch";
 import fs from "fs";
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,11 +6,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "e2e": "npx playwright test",
-    "update-data": "ts-node -r tsconfig-paths/register bin/update-local-data.ts",
-    "migrate-users": "ts-node -r tsconfig-paths/register bin/migrate-users.ts",
-    "sync-slack-users": "ts-node -r tsconfig-paths/register bin/sync-slack-users.ts",
-    "sync-ecomail-subscribers": "ts-node -r tsconfig-paths/register bin/sync-ecomail-subscribers.ts"
+    "e2e": "npx playwright test"
   },
   "dependencies": {
     "airtable": "^0.11.3",
@@ -42,7 +38,7 @@
     "@types/react-test-renderer": "^17.0.1",
     "@types/sharp": "^0.29.4",
     "@types/styled-components": "^5.1.17",
-    "dotenv": "^16.0.0",
+    "dotenv-flow": "^3.2.0",
     "eslint": "8.4.0",
     "eslint-config-next": "^12.1.4",
     "jest": "^27.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,7 +464,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.17.8":
+"@babel/runtime@^7.16.7":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -2161,10 +2161,17 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dotenv@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
-  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+dotenv-flow@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-3.2.0.tgz#a5d79dd60ddb6843d457a4874aaf122cf659a8b7"
+  integrity sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==
+  dependencies:
+    dotenv "^8.0.0"
+
+dotenv@^8.0.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 elastic-apm-http-client@11.0.1:
   version "11.0.1"


### PR DESCRIPTION
@karmi, tohle je spíš FYI – přišel jsem na mírně jednodušší způsob, jak spouštět pomocné skripty v TypeScriptu, tak jsem je vyházel z `package.json` a udělal z nich regulérní shell skripty. (Proměnné prostředí s klíči a podobně se automaticky načtou z `.env.local`, máš-li. Je potřeba binárka `ts-node`.)