### PR TITLE
Add defensive loading of data from Airtable

### DIFF
--- a/pages/opportunities/[slug].tsx
+++ b/pages/opportunities/[slug].tsx
@@ -88,6 +88,7 @@ const Page: NextPage<PageProps> = (props) => {
                 <TimeIcon />
                 <Body>{opportunity.timeRequirements}</Body>
               </S.OpportunityMetaRow>
+              { owner && (
               <S.OpportunityOwnerWrapper>
                 <Body>Kontaktní osoba</Body>
                 <S.OwnerWrapper>
@@ -95,6 +96,7 @@ const Page: NextPage<PageProps> = (props) => {
                   <OwnerContact email={owner.email} name={owner.name} />
                 </S.OwnerWrapper>
               </S.OpportunityOwnerWrapper>
+              )}
               <a href={opportunity.contactUrl} target="blank">
                 <S.OpportunityContactButton>
                   {getContactButtonLabel(opportunity.contactUrl)}

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -192,7 +192,7 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
   const project = projects.find((p) => p.slug === slug)!;
   const coordinators = project.coordinatorIds.map(
     (id) => users.find((user) => user.id === id)!
-  );
+  ).filter((c) => c !== undefined);
   const opportunities = siteData.opportunities.filter(
     (o) => o.projectId === project.id && o.status === "live"
   );


### PR DESCRIPTION
This patch prevents build failure due to inconsistency in Airtable data.

The builds have been failing due to problems with opportunity owners:

    Error occurred prerendering page "/opportunities/recxWt15iPiGXW6Va". Read more: https://nextjs.org/docs/messages/prerender-error
    18:52:50.565  TypeError: Cannot read property 'profilePictureUrl' of undefined
    18:52:50.565      at Page (/vercel/path0/.next/server/pages/opportunities/[slug].js:407:72)
    18:52:50.565

And with project coordinators:

    Error occurred prerendering page "/projects/jehlomat". Read more: https://nextjs.org/docs/messages/prerender-error
    18:52:51.594  Error: Error serializing `.coordinators[3]` returned from `getStaticProps` in "/projects/[slug]".
    18:52:51.594  Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
    18:52:51.594

We need to improve checking the data and also error reporting.