### PR TITLE
Add defensive 'notFound' when loading events

### DIFF
--- a/pages/events/[slug].tsx
+++ b/pages/events/[slug].tsx
@@ -117,6 +117,7 @@ export const getStaticProps: GetStaticProps<PageProps, QueryParams> = async (
   const owner = users.find((u) => u.id === event.ownerId)!;
   return {
     props: { event, events, project, projects, owner },
+    notFound: ( !event || !project || !owner ),
   };
 };
 


### PR DESCRIPTION
The build has been failing with:

   Error occurred prerendering page "/events/7-duvodu-proc-statni-it-nefunguje". Read more: https://nextjs.org/docs/messages/prerender-error
   Error: Error serializing `.project` returned from `getStaticProps` in "/events/[slug]".
   Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.

This patch adds the `notFound` property to return value of getStaticProps(), see doc at:
https://nextjs.org/docs/api-reference/data-fetching/get-static-props#notfound