### PR TITLE
Načítání kontaktního e-mailu z profilu Slacku

### DIFF
--- a/lib/airtable/slack-user.ts
+++ b/lib/airtable/slack-user.ts
@@ -37,6 +37,7 @@ export const decodeSlackUser = record({
   slackId: string,
   name: string,
   email: optional(string),
+  contactEmail: optional(string),
   slackAvatarUrl: optional(string),
   userProfileRelationId: field("userProfile", relationToOne),
 });
@@ -47,6 +48,7 @@ export function encodeSlackUser(user: Partial<SlackUser>): Partial<Schema> {
     id: user.id,
     name: user.name,
     email: user.email,
+    contactEmail: user.contactEmail,
     slackId: user.slackId,
     slackAvatarUrl: user.slackAvatarUrl,
     userProfile: user.userProfileRelationId

--- a/lib/decoding.test.ts
+++ b/lib/decoding.test.ts
@@ -1,5 +1,5 @@
-import { number } from "typescript-json-decoder";
-import { decodeUrl, decodeValidItemsFromArray } from "./decoding";
+import { number, record, string } from "typescript-json-decoder";
+import { decodeObject, decodeUrl, decodeValidItemsFromArray } from "./decoding";
 
 test("Decode URL", () => {
   expect(() => decodeUrl("bagr")).toThrow();
@@ -14,4 +14,14 @@ test("Decode URL", () => {
 test("Decode valid items from array", () => {
   const decoder = decodeValidItemsFromArray(number, "Test", () => {});
   expect(decoder(["foo", "bar", 42])).toEqual([42]);
+});
+
+test("Decode object", () => {
+  const decoder = decodeObject(record({ name: string, age: number }));
+  expect(decoder({ userA: { name: "Miles", age: 42 } })).toEqual({
+    userA: {
+      name: "Miles",
+      age: 42,
+    },
+  });
 });

--- a/lib/decoding.ts
+++ b/lib/decoding.ts
@@ -1,7 +1,9 @@
 import { MarkdownString } from "./utils";
 import {
   array,
+  Decoder,
   DecoderFunction,
+  decodeType,
   dict,
   Pojo,
   string,
@@ -58,6 +60,13 @@ export const decodeDictValues =
   <T>(decodeItem: DecoderFunction<T>) =>
   (value: Pojo) =>
     [...dict(decodeItem)(value).values()];
+
+/** Decode an object with given entries */
+export function decodeObject<D extends Decoder<unknown>>(
+  decoder: D
+): DecoderFunction<Record<string, decodeType<D>>> {
+  return (value: Pojo) => Object.fromEntries(dict(decoder)(value));
+}
 
 /**
  * Decode skills such as Marketing, Design, …

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -35,6 +35,7 @@ export async function confirmUserAccount(slackId: string) {
     slackId: slackUser.id,
     name: slackUser.real_name || slackUser.name,
     email: slackUser.profile.email,
+    contactEmail: undefined,
     slackAvatarUrl: slackUser.profile.image_512,
     userProfileRelationId: undefined,
   });

--- a/lib/slack/user.test.ts
+++ b/lib/slack/user.test.ts
@@ -24,5 +24,19 @@ test("Decode profile", () => {
     display_name: "Tomáš Znamenáček",
     image_512: "https://…512.png",
     email: undefined,
+    fields: {
+      Xf01F0M3N546: {
+        alt: "",
+        value: "zoul@cesko.digital",
+      },
+      XfNQG9GG77: {
+        alt: "",
+        value: "velmi aktivně (10+h/týdně)",
+      },
+      XfRZG8T8TU: {
+        alt: "",
+        value: "https://github.com/zoul",
+      },
+    },
   });
 });


### PR DESCRIPTION
Fixes #630. Co jsem udělal:

* Přidal jsem funkci pro načítání profilu ze Slacku
* Přidal jsem do tabulky Slack Users nové pole `contactEmail`
* Rozšířil jsem skript pro synchronizaci uživatelů, aby do tohoto nového pole ukládal email z profilu na Slacku