### PR TITLE
Přidávat nové odběratele newsletteru do preferenční skupiny číst.digital

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S npx ts-node -r tsconfig-paths/register -r dotenv-flow/config
+
+const toJSON = (val: any) => JSON.stringify(val, null, 2);
+
+async function main() {
+  // Your code here
+}
+
+main().catch((error) => console.log(error));
+
+export {};

--- a/lib/decoding.ts
+++ b/lib/decoding.ts
@@ -5,6 +5,7 @@ import {
   DecoderFunction,
   decodeType,
   dict,
+  nil,
   Pojo,
   string,
   undef,
@@ -27,10 +28,10 @@ export const takeFirst = <T>(decoder: DecoderFunction<T[]>) => {
   };
 };
 
-/** Decode `undefined` as an empty array */
+/** Decode `undefined` and `null` as an empty array */
 export const optionalArray = <T>(itemDecoder: DecoderFunction<T>) => {
   return (value: Pojo) => {
-    const decoder = union(undef, array(itemDecoder));
+    const decoder = union(undef, nil, array(itemDecoder));
     const decoded = decoder(value);
     return decoded ?? [];
   };

--- a/lib/ecomail.ts
+++ b/lib/ecomail.ts
@@ -11,7 +11,7 @@ import {
 } from "typescript-json-decoder";
 
 /** The Ecomail ID of our main newsletter list */
-export const newsletterListId = 2;
+export const mainContactListId = 2;
 
 /** All possible subscription states */
 export const subscriptionStates = [
@@ -84,7 +84,7 @@ export async function getSubscriber(
 export async function subscribeToList(
   apiKey: string,
   email: string,
-  listId = newsletterListId,
+  listId = mainContactListId,
   tags: string[] = []
 ): Promise<boolean> {
   const payload = {
@@ -106,7 +106,7 @@ export async function subscribeToList(
 export async function unsubscribeFromList(
   apiKey: string,
   email: string,
-  listId = newsletterListId
+  listId = mainContactListId
 ): Promise<boolean> {
   const response = await fetch(
     `https://api2.ecomailapp.cz/lists/${listId}/unsubscribe`,
@@ -130,7 +130,7 @@ export async function unsubscribeFromList(
 export async function addSubscribers(
   apiKey: string,
   emails: string[],
-  listId = newsletterListId
+  listId = mainContactListId
 ): Promise<void> {
   const maxBatchSize = 500;
   for (const batch of splitToChunks(emails, maxBatchSize)) {

--- a/lib/ecomail.ts
+++ b/lib/ecomail.ts
@@ -14,6 +14,21 @@ import {
 /** The Ecomail ID of our main newsletter list */
 export const mainContactListId = 2;
 
+/** The Ecomail ID of our primary preference group */
+export const mainPreferenceGroupId = "grp_6299c0823feb1";
+
+/** Our main preference group options */
+export const mainPreferenceGroupOptions = [
+  "číst.digital",
+  "náborový newsletter",
+  "neziskový newsletter",
+  "jen to nejdůležitější",
+] as const;
+
+/** Our main preference group options */
+export type MainPreferenceGroupOption =
+  typeof mainPreferenceGroupOptions[number];
+
 /** All possible subscription states */
 export const subscriptionStates = [
   "subscribed",
@@ -125,16 +140,36 @@ export async function getSubscriber(
     .then((w) => w.subscriber);
 }
 
-/** Subscribe contact to given list, will resubscribe if unsubcribed */
+/** Subscribe contact to given list */
 export async function subscribeToList(
   apiKey: string,
-  email: string,
-  listId = mainContactListId,
-  tags: string[] = []
+  subscription: {
+    /** Subscriber email */
+    email: string;
+    /** ID of the contact list to subscribe to, defaults to our main contact list */
+    listId?: number;
+    /** Tags to set */
+    tags?: string[];
+    /** Preference groups to set */
+    groups?: MainPreferenceGroupOption[];
+    /** Should the subscriber be resubscribed if needed? Defaults to `true`. */
+    resubscribe?: boolean;
+  }
 ): Promise<boolean> {
+  const {
+    email,
+    listId = mainContactListId,
+    tags = [],
+    groups = [],
+    resubscribe = true,
+  } = subscription;
   const payload = {
-    subscriber_data: { email, tags },
-    resubscribe: true,
+    subscriber_data: {
+      email,
+      tags,
+      groups: { [mainPreferenceGroupId]: groups },
+    },
+    resubscribe,
   };
   const response = await fetch(
     `https://api2.ecomailapp.cz/lists/${listId}/subscribe`,

--- a/lib/ecomail.ts
+++ b/lib/ecomail.ts
@@ -164,9 +164,17 @@ export async function subscribeToList(
     email: string;
     /** ID of the contact list to subscribe to, defaults to our main contact list */
     listId?: number;
-    /** Tags to set */
+    /**
+     * Tags to set
+     *
+     * NOTE: The value will overwrite any existing tags.
+     */
     tags?: string[];
-    /** Preference groups to set */
+    /**
+     * Preference groups to set
+     *
+     * NOTE: The value will overwrite any existing groups.
+     */
     groups?: MainPreferenceGroupOption[];
     /** Should the subscriber be resubscribed if needed? Defaults to `true`. */
     resubscribe?: boolean;
@@ -175,15 +183,15 @@ export async function subscribeToList(
   const {
     email,
     listId = mainContactListId,
-    tags = [],
-    groups = [],
+    tags,
+    groups,
     resubscribe = true,
   } = subscription;
   const payload = {
     subscriber_data: {
       email,
       tags,
-      groups: { [mainPreferenceGroupId]: groups },
+      groups: groups ? { [mainPreferenceGroupId]: groups } : undefined,
     },
     resubscribe,
   };

--- a/pages/api/newsletter.ts
+++ b/pages/api/newsletter.ts
@@ -1,4 +1,4 @@
-import { mainContactListId, subscribeToList } from "lib/ecomail";
+import { subscribeToList } from "lib/ecomail";
 import { NextApiRequest, NextApiResponse } from "next";
 
 const handler = async (
@@ -18,12 +18,10 @@ const handler = async (
   }
 
   try {
-    const success = await subscribeToList(
-      process.env.ECOMAIL_API_KEY || "",
-      body.email,
-      mainContactListId,
-      ["web-subscribe-form"]
-    );
+    const success = await subscribeToList(process.env.ECOMAIL_API_KEY || "", {
+      email: body.email,
+      tags: ["web-subscribe-form"],
+    });
     if (!success) {
       response.status(500).send("Unexpected error");
       return;

--- a/pages/api/newsletter.ts
+++ b/pages/api/newsletter.ts
@@ -1,4 +1,4 @@
-import { newsletterListId, subscribeToList } from "lib/ecomail";
+import { mainContactListId, subscribeToList } from "lib/ecomail";
 import { NextApiRequest, NextApiResponse } from "next";
 
 const handler = async (
@@ -21,7 +21,7 @@ const handler = async (
     const success = await subscribeToList(
       process.env.ECOMAIL_API_KEY || "",
       body.email,
-      newsletterListId,
+      mainContactListId,
       ["web-subscribe-form"]
     );
     if (!success) {

--- a/pages/api/newsletter.ts
+++ b/pages/api/newsletter.ts
@@ -21,6 +21,7 @@ const handler = async (
     const success = await subscribeToList(process.env.ECOMAIL_API_KEY || "", {
       email: body.email,
       tags: ["web-subscribe-form"],
+      groups: ["číst.digital"],
     });
     if (!success) {
       response.status(500).send("Unexpected error");

--- a/pages/api/protected/newsletter_subscription.ts
+++ b/pages/api/protected/newsletter_subscription.ts
@@ -39,7 +39,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
         const newSub = decodeRequest(request.body);
         switch (newSub.state) {
           case "subscribed":
-            await subscribeToList(apiKey, email, mainContactListId);
+            await subscribeToList(apiKey, { email });
             response.status(204).end();
             break;
           case "unsubscribed":

--- a/pages/api/protected/newsletter_subscription.ts
+++ b/pages/api/protected/newsletter_subscription.ts
@@ -3,7 +3,7 @@ import { getToken } from "next-auth/jwt";
 import { decodeType, record, union } from "typescript-json-decoder";
 import {
   getSubscriber,
-  newsletterListId,
+  mainContactListId,
   subscribeToList,
   subscriptionStates,
   unsubscribeFromList,
@@ -27,7 +27,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
       case "GET":
         const subscriber = await getSubscriber(apiKey, email);
         const previousSub = subscriber.lists.find(
-          (list) => list.listId === newsletterListId
+          (list) => list.listId === mainContactListId
         );
         const subscription: SubscriptionResponse = {
           state: previousSub?.state || "unsubscribed",
@@ -39,11 +39,11 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
         const newSub = decodeRequest(request.body);
         switch (newSub.state) {
           case "subscribed":
-            await subscribeToList(apiKey, email, newsletterListId);
+            await subscribeToList(apiKey, email, mainContactListId);
             response.status(204).end();
             break;
           case "unsubscribed":
-            await unsubscribeFromList(apiKey, email, newsletterListId);
+            await unsubscribeFromList(apiKey, email, mainContactListId);
             response.status(204).end();
             break;
           default:


### PR DESCRIPTION
Součást #707, tahle změna přidává kód pro správu preferenčních skupin a mění chování formuláře na webu tak, aby nové odběratele přidával do skupiny `číst.digital`. @lukasnavesnik, za tebe v pořádku? (Neptám se ani tak na kód, jako spíš to chování, jestli jsme se někde špatně nepochopili.) ⚠️ V kódu je napevno název preferenční skupiny `číst.digital`, takže pokud ju přejmenujeme v Ecomailu, je potřeba to reflektovat i v kódu.

PS. Po nasazení bude dobré vyzkoušet a ještě případně zpětně nastavit skupinu `číst.digital` u všech odběratelů s tagem `web-subscribe-form`.