### PR TITLE
Add trend graphs for new comers engagements

### DIFF
--- a/app/stats/basics.e2e.ts
+++ b/app/stats/basics.e2e.ts
@@ -9,6 +9,8 @@ const endpoints = [
   "/api/stats/skills/subcategories",
   "/api/stats/occupations",
   "/stats/trends/new-comers?year=2022&fill=true",
+  "/stats/trends/new-comers-engagements?year=2022&fill=true",
+  "/stats/trends/new-engagements?year=2022&fill=true",
 ];
 
 for (const endpoint of endpoints) {

--- a/app/stats/trends/new-comers-engagements/route.ts
+++ b/app/stats/trends/new-comers-engagements/route.ts
@@ -1,7 +1,7 @@
 import { getCsvResponse } from "../trend-response";
 import { buildTrendStats } from "../trend-stats";
 import { buildTrendOptions } from "../trend-request";
-import { generateNewComersTrend } from "../trends";
+import { generateNewComersTrend, generateNewEngagementsTrend } from "../trends";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -9,7 +9,16 @@ export async function GET(request: Request) {
   return await getCsvResponse(async function (): Promise<string | null> {
     return await buildTrendStats(
       buildTrendOptions(searchParams),
-      generateNewComersTrend
+      [
+        {
+          title: "Zapojeni do projektu",
+          generate: generateNewEngagementsTrend
+        },
+        {
+          title: "Noví dobrovolníci",
+          generate: generateNewComersTrend
+        }
+      ]
     )
   })
 }

--- a/app/stats/trends/new-engagements/route.ts
+++ b/app/stats/trends/new-engagements/route.ts
@@ -1,7 +1,7 @@
 import { getCsvResponse } from "../trend-response";
 import { buildTrendStats } from "../trend-stats";
 import { buildTrendOptions } from "../trend-request";
-import { generateNewComersTrend } from "../trends";
+import { generateNewEngagementsTrend } from "../trends";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -9,7 +9,7 @@ export async function GET(request: Request) {
   return await getCsvResponse(async function (): Promise<string | null> {
     return await buildTrendStats(
       buildTrendOptions(searchParams),
-      generateNewComersTrend
+      generateNewEngagementsTrend
     )
   })
 }

--- a/app/stats/trends/trend-request.ts
+++ b/app/stats/trends/trend-request.ts
@@ -29,10 +29,10 @@ function getYear(query: URLSearchParams, key: string = "year"): number | null {
 }
 
 /**
- * Gets fill query parameter. If not set, false is returned.
+ * Gets bool query parameter. If not set, false is returned.
  */
-function shouldAutoFill(query: URLSearchParams): boolean {
-  const fillYear = query.get("fill");
+function getBool(query: URLSearchParams, key: string): boolean {
+  const fillYear = query.get(key);
 
   if (fillYear === null) {
     return false;
@@ -47,6 +47,6 @@ export function buildTrendOptions(query: URLSearchParams): TrendOptions {
   return {
     fromYear: getYear(query, "from") ?? year,
     toYear: getYear(query, "to") ?? year,
-    autoFill: shouldAutoFill(query),
+    autoFill: getBool(query, "fill"),
   };
 }

--- a/app/stats/trends/trends.ts
+++ b/app/stats/trends/trends.ts
@@ -1,0 +1,33 @@
+import { WriteTrendValue } from "./trend-stats";
+import { getAllTeamEngagements } from "../../../lib/airtable/team-engagement";
+import { getAllUserProfiles } from "../../../lib/airtable/user-profile";
+
+export async function generateNewComersTrend(writeTrendValue: WriteTrendValue): Promise<void> {
+  const userProfiles = await getAllUserProfiles("Confirmed Profiles");
+
+  // At the moment of writing there is 5975 rows, we want to avoid doing multiple loops to make this code
+  // as fast as possible.
+  for (const profile of userProfiles) {
+    if (!profile.createdAt) {
+      continue;
+    }
+
+    writeTrendValue({
+      date: new Date(profile.createdAt),
+    });
+  }
+}
+
+export async function generateNewEngagementsTrend(writeTrendValue: WriteTrendValue): Promise<void> {
+  const teamEngagements = await getAllTeamEngagements();
+
+  for (const engagement of teamEngagements) {
+    if (!engagement.startDate) {
+      continue
+    }
+
+    writeTrendValue({
+      date: new Date(engagement.startDate),
+    });
+  }
+}

--- a/lib/airtable/team-engagement.ts
+++ b/lib/airtable/team-engagement.ts
@@ -38,6 +38,7 @@ export const decodeTeamEngagement = record({
   projectName: relationToOne,
   coordinatingRole: withDefault(boolean, false),
   inactive: withDefault(boolean, false),
+  startDate: optional(string)
 });
 
 //


### PR DESCRIPTION
@GabiChl Dle domluvy přidávám nové url adresy pro grafy:

- Zařazení do projektu - `stats/trends/new-engagements`
- Zařazení do projektu vs přihlášení dobrovolníci - `stats/trends/new-comers-engagements`

Tento trend obsahuje sloučené trendy a jsou 2 režimy jak se můžou data zobrazit:

- Pomocí area chart: https://www.datawrapper.de/_/wjPBe/
- Pomocí Stacked column chart: https://www.datawrapper.de/_/Xrj0p/

U stacked column chart je nutné prohodit řádky se sloupci (jednoduší než udržovat na to speciální kód). To se dělá v druhém kroku

<img width="1007" alt="Snímek obrazovky 2023-03-25 v 20 22 15" src="https://user-images.githubusercontent.com/1878831/227737457-e8f15f6c-f238-4bf9-a7ba-dc2bcaf727e9.png">

Trend adresy podporují stejné parametry jako v #745 

@zoul prosím o deploy

