### PR TITLE
Všechny profilové obrázky u mapy dobrovolníků mají stejnou velikost

### DIFF
--- a/app/profile/map/index.tsx
+++ b/app/profile/map/index.tsx
@@ -104,7 +104,7 @@ const MemberCard = ({ member }: { member: MapMember }) => (
         member.slackAvatarUrl ||
         "https://data.cesko.digital/people/generic-profile.jpg"
       }
-      className="border-it border-2 rounded-full"
+      className="border-it border-2 rounded-full aspect-square object-cover object-top"
       width={70}
       height={70}
       alt=""


### PR DESCRIPTION
Fixes #863 

- Koukal jsem, že se profilové fotky lidí tahají ze Slacku. Zběžně jsem nějaké fotografie projel a všechny, až na tuto jednu, jsou poměru stran 1:1. Nevím, jak se to stalo a možná by bylo lepší vyřešit příčinu, ne symptom.
- Na druhou stranu, asi je fajn mít podchycené i nějaké edge-cases a takto bychom měli zajistit, že libovolná fotka bude v 70x70 kolečku.
- `object-position: top;` funguje v tomto konkrétním případě, ale samozřejmě nemusí v jiném. To je čistě závislé na konkrétní fotce. Vycházel jsem z předpokladu, že když si někdo nahrává profilovou fotku, spíš se tam umístí i s kusem torsa než že by nad sebou/vedle sebe nechal volné místo. To může být mylná představa; pak mě napadá použít `object-fit: contain;` – fotka se pak zobrazí kompletní, ale s bílými okraji: 
  <img width="79" alt="image" src="https://github.com/cesko-digital/web/assets/28192993/6c0aa6ec-d3a4-4e8b-a433-c788a5d5d2a2">
