### PR TITLE
feat: tab bar with hash navigation

### DIFF
--- a/app/profile/SignedInPage.tsx
+++ b/app/profile/SignedInPage.tsx
@@ -14,22 +14,27 @@ export const SignedInPage = ({ session }: { session: Session }) => {
   const tabs = [
     {
       title: "Dovednosti",
+      hash: "skills",
       content: <SkillsTab />,
     },
     {
       title: "Newslettery",
+      hash: "newsletter",
       content: <NewsletterTab userMail={session.user!.email!} />,
     },
     {
       title: "Notifikace",
+      hash: "notifications",
       content: <NotificationsTab userEmail={session.user!.email!} />,
     },
     {
       title: "Mapa komunity",
+      hash: "community-map",
       content: <MapTab />,
     },
     {
       title: "Soukromí",
+      hash: "privacy",
       content: <PrivacyTab />,
     },
   ];

--- a/app/stats/StatsTabBar.tsx
+++ b/app/stats/StatsTabBar.tsx
@@ -16,10 +16,12 @@ export const StatsTabBar = ({ metrics, samples }: Props) => (
     items={[
       {
         title: "Metriky",
+        hash: "metrics",
         content: <MetricsTab metrics={metrics} samples={samples} />,
       },
       {
         title: "Nově příchozí",
+        hash: "newcomers",
         content: (
           <Section>
             <DatawrapperChart id="M1Dm2" />
@@ -29,6 +31,7 @@ export const StatsTabBar = ({ metrics, samples }: Props) => (
       },
       {
         title: "Dovednosti",
+        hash: "skills",
         content: (
           <Section>
             <div className="flex flex-col gap-7">
@@ -41,6 +44,7 @@ export const StatsTabBar = ({ metrics, samples }: Props) => (
       },
       {
         title: "Regionální rozložení",
+        hash: "regions",
         content: (
           <Section>
             <DatawrapperChart id="SopS3" />
@@ -50,6 +54,7 @@ export const StatsTabBar = ({ metrics, samples }: Props) => (
       },
       {
         title: "Hledané role",
+        hash: "roles",
         content: (
           <Section>
             <DatawrapperChart id="VZWTt" />

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -1,41 +1,32 @@
-import { useState } from "react";
-
 import clsx from "clsx";
+
+import useHash from '~/components/hooks/hash';
 
 export type Item<Key> = {
   key: Key;
   title: string;
+  hash: string;
 };
 
 export type Props<Key> = {
   items: Item<Key>[];
-  defaultActiveKey?: Key;
+  activeKey: Key;
   onChange?: (key: Key) => void;
 };
 
 /** TBD: Improve on mobile */
 export const TabBar = <Key extends string>({
   items,
-  defaultActiveKey,
+  activeKey,
   onChange,
 }: Props<Key>) => {
-  const [activeKey, setActiveKey] = useState<Key>(
-    defaultActiveKey ?? items[0].key,
-  );
-
-  const clickHandler = (key: Key) => {
-    setActiveKey(key);
-    if (onChange) {
-      onChange(key);
-    }
-  };
-
   const Tab = (item: Item<Key>) => {
     const isActive = activeKey === item.key;
     return (
       <li key={item.key} className="me-2">
         <a
-          onClick={() => clickHandler(item.key)}
+          href={`#${item.hash}`}
+          onClick={() => onChange && onChange(item.key)}
           className={clsx(
             "inline-block cursor-pointer whitespace-nowrap border-b-2 p-4",
             isActive ? "border-it" : "border-transparent",
@@ -58,18 +49,21 @@ export const TabBar = <Key extends string>({
 
 export type SimpleItem = {
   title: string;
+  hash: string;
   content: React.ReactNode;
 };
 
 export const SimpleTabBar = ({ items }: { items: SimpleItem[] }) => {
-  const [activeKey, setActiveKey] = useState(items[0].title);
+  const hash = useHash();
+  const activeItem = items.find((item) => item.hash === hash) ?? items[0];
+
   return (
     <div className="flex flex-col gap-7">
       <TabBar
-        items={items.map(({ title }) => ({ key: title, title }))}
-        onChange={setActiveKey}
+        items={items.map(({ title, hash }) => ({ key: title, title, hash }))}
+        activeKey={activeItem.title}
       />
-      {items.find((item) => item.title === activeKey)?.content}
+      {activeItem.content}
     </div>
   );
 };


### PR DESCRIPTION
Closes #955 

Prozatím jsem to udělal dle zadání jako hash router. Má to ale jednu nevýhodu ve spojení s SSR – jelikož se část za hashem nikdy neodesílá na server, vždy dojde nejdřív k vyrenderování výchozího (prvního) tabu a až při hydrataci na klientovi se to přerenderuje na správnou záložku. V reálnym nasazení to asi není moc velkej problém, protože to člověk většinu času ani nepostřehne (lze vidět např. [zde](https://app-ionjhx3ax-ceskodigital.vercel.app/stats#regions)). V lokálním setupu při vývoji je to ale dost markantní a pomalejší klienti by s tim možná mohli mít stejnej problém?