### PR TITLE
Nahrávací obrazovky

### DIFF
--- a/app/projects/[slug]/loading.tsx
+++ b/app/projects/[slug]/loading.tsx
@@ -1,0 +1,16 @@
+import { Breadcrumbs } from "~/components/Breadcrumbs";
+import { Route } from "~/src/routing";
+
+export default function Loading() {
+  return (
+    <main className="m-auto max-w-content px-7 py-20">
+      <Breadcrumbs
+        path={[
+          { label: "Homepage", path: "/" },
+          { label: "Projekty", path: Route.projects },
+        ]}
+        currentPage="…"
+      />
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #989, tohle je zatím jen ukázka. Nahrávací obrazovka se zatím vůbec neukazuje, protože navigace zůstane viset na funkci `generateMetadata`, to bude potřeba domyslet (viz https://github.com/vercel/next.js/discussions/50104).