### PR TITLE
Podrobné stránky pro statistiky

### DIFF
--- a/app/stats/DetailedChart.tsx
+++ b/app/stats/DetailedChart.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { type AxisConfig } from "@mui/x-charts";
+import { LineChart } from "@mui/x-charts/LineChart";
+
+import { type MetricDefinition, type MetricSample } from "~/src/data/metrics";
+
+export const DetailedChart = ({
+  metric,
+  filteredSamples: samples,
+}: {
+  metric: MetricDefinition;
+  filteredSamples: MetricSample[];
+}) => {
+  type Axis = Omit<AxisConfig, "id">;
+  const dateFormatter = new Intl.DateTimeFormat("cs-CZ", {
+    day: "numeric",
+    month: "long",
+  });
+  const numberFormatter = new Intl.NumberFormat("cs-CZ", {
+    notation: "compact",
+  });
+  const formatNumber = (value: number) => numberFormatter.format(value);
+  const data = samples.map((s) => s.value);
+  const timeAxis: Axis = {
+    data: samples.map((s) => new Date(s.date)),
+    scaleType: "time",
+    valueFormatter: (value) => dateFormatter.format(value as Date),
+  };
+  const bandAxis: Axis = {
+    data: samples.map((s) => s.label),
+    scaleType: "band",
+  };
+  return (
+    <div>
+      <div className="bg-pebble p-4">
+        <LineChart
+          colors={["blue"]}
+          height={300}
+          series={[
+            {
+              data,
+              valueFormatter: formatNumber,
+            },
+          ]}
+          yAxis={[
+            {
+              min: 0,
+              valueFormatter: formatNumber,
+            },
+          ]}
+          xAxis={[metric.type === "band" ? bandAxis : timeAxis]}
+        />
+      </div>
+    </div>
+  );
+};

--- a/app/stats/Metrics.tsx
+++ b/app/stats/Metrics.tsx
@@ -69,7 +69,7 @@ const ServiceSection = ({
   );
 };
 
-export const MetricBox = ({
+const MetricBox = ({
   metric,
   filteredSamples: samples,
 }: {

--- a/app/stats/Metrics.tsx
+++ b/app/stats/Metrics.tsx
@@ -1,12 +1,11 @@
-"use client";
+import Link from "next/link";
 
 import { type AxisConfig } from "@mui/x-charts";
 import { LineChart } from "@mui/x-charts/LineChart";
 
 import { type MetricDefinition, type MetricSample } from "~/src/data/metrics";
-import { unique } from "~/src/utils";
-import Link from "next/link";
 import { Route } from "~/src/routing";
+import { unique } from "~/src/utils";
 
 export type Props = {
   metrics: MetricDefinition[];
@@ -99,8 +98,8 @@ export const MetricBox = ({
   return (
     <Link
       key={metric.slug}
-      className="flex flex-col overflow-clip rounded-lg bg-pebble"  
-      href={Route.toMetric(metric)}    
+      className="flex flex-col overflow-clip rounded-lg border-2 border-gray bg-pebble hover:border-it hover:shadow-lg"
+      href={Route.toMetric(metric)}
     >
       <div className="p-4">
         <LineChart

--- a/app/stats/Metrics.tsx
+++ b/app/stats/Metrics.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import { type AxisConfig } from "@mui/x-charts";
 import { LineChart } from "@mui/x-charts/LineChart";
 
 import { type MetricDefinition, type MetricSample } from "~/src/data/metrics";
 import { unique } from "~/src/utils";
+import Link from "next/link";
+import { Route } from "~/src/routing";
 
 export type Props = {
   metrics: MetricDefinition[];
@@ -66,7 +70,7 @@ const ServiceSection = ({
   );
 };
 
-const MetricBox = ({
+export const MetricBox = ({
   metric,
   filteredSamples: samples,
 }: {
@@ -93,9 +97,10 @@ const MetricBox = ({
     scaleType: "band",
   };
   return (
-    <div
+    <Link
       key={metric.slug}
-      className="flex flex-col overflow-clip rounded-lg bg-pebble"
+      className="flex flex-col overflow-clip rounded-lg bg-pebble"  
+      href={Route.toMetric(metric)}    
     >
       <div className="p-4">
         <LineChart
@@ -122,6 +127,6 @@ const MetricBox = ({
           <p className="typo-caption">{metric.description}</p>
         )}
       </div>
-    </div>
+    </Link>
   );
 };

--- a/app/stats/[slug]/page.tsx
+++ b/app/stats/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from "next/navigation";
+
+import { Breadcrumbs } from "~/components/Breadcrumbs";
+import {
+  getAllMetricDefinitions,
+  getAllMetricSamples,
+} from "~/src/data/metrics";
+import { Route } from "~/src/routing";
+
+import { MetricBox } from "../Metrics";
+
+type Params = {
+  slug: string;
+};
+
+type Props = {
+  params: Params;
+};
+
+const Page = async ({ params }: Props) => {
+  const metrics = await getAllMetricDefinitions();
+  const allSamples = await getAllMetricSamples();
+  const metric = metrics.find((m) => m.slug === params.slug);
+  const samples = allSamples.filter((s) => s.metricSlug === params.slug);
+  if (!metric) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <main className="m-auto max-w-content px-7 py-20">
+        <Breadcrumbs
+          path={[
+            { label: "Homepage", path: "/" },
+            { label: "Statistiky", path: Route.stats },
+          ]}
+          currentPage={metric.name}
+        />
+        <h1 className="typo-title mb-2 mt-7">{metric.qualifiedName}</h1>
+        <h2 className="typo-subtitle mb-10 max-w-prose">
+          {metric.description && metric.description}
+        </h2>
+        {/* place for graph, currently used MetricBox but it is not the cleanest solution... */}
+        <MetricBox metric={metric} filteredSamples={samples} />
+      </main>
+    </div>
+  );
+};
+
+export default Page;

--- a/app/stats/[slug]/page.tsx
+++ b/app/stats/[slug]/page.tsx
@@ -1,13 +1,13 @@
 import { notFound } from "next/navigation";
 
+import { DetailedChart } from "~/app/stats/DetailedChart";
 import { Breadcrumbs } from "~/components/Breadcrumbs";
 import {
   getAllMetricDefinitions,
   getAllMetricSamples,
+  type MetricSample,
 } from "~/src/data/metrics";
 import { Route } from "~/src/routing";
-
-import { MetricBox } from "../Metrics";
 
 type Params = {
   slug: string;
@@ -21,7 +21,14 @@ const Page = async ({ params }: Props) => {
   const metrics = await getAllMetricDefinitions();
   const allSamples = await getAllMetricSamples();
   const metric = metrics.find((m) => m.slug === params.slug);
-  const samples = allSamples.filter((s) => s.metricSlug === params.slug);
+
+  const compareSamplesByDate = (a: MetricSample, b: MetricSample) =>
+    new Date(a.date).getTime() - new Date(b.date).getTime();
+
+  const samples = allSamples
+    .filter((s) => s.metricSlug === params.slug)
+    .sort(compareSamplesByDate);
+
   if (!metric) {
     notFound();
   }
@@ -36,12 +43,17 @@ const Page = async ({ params }: Props) => {
           ]}
           currentPage={metric.name}
         />
-        <h1 className="typo-title mb-2 mt-7">{metric.qualifiedName}</h1>
-        <h2 className="typo-subtitle mb-10 max-w-prose">
-          {metric.description && metric.description}
-        </h2>
-        {/* place for graph, currently used MetricBox but it is not the cleanest solution... */}
-        <MetricBox metric={metric} filteredSamples={samples} />
+        <h1
+          className={`typo-title ${metric.description ? "mb-3" : "mb-10"} mt-7`}
+        >
+          {metric.service} | {metric.name}
+        </h1>
+        {metric.description && (
+          <h2 className="typo-subtitle mb-10 max-w-prose">
+            {metric.description}
+          </h2>
+        )}
+        <DetailedChart metric={metric} filteredSamples={samples} />
       </main>
     </div>
   );

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,6 +1,7 @@
 import { type Event } from "./data/event";
 import { type Opportunity } from "./data/opportunity";
 import { type Project } from "./data/project";
+import { type MetricDefinition } from "./data/metrics";
 
 /** Create URLs for frequently used routes */
 export const Route = {
@@ -16,6 +17,7 @@ export const Route = {
   register: "/join",
   signIn: "/sign-in",
   userProfile: "/profile",
+  stats: "/stats",
   // More static routes
   eventFeed: "/events/feed.ical",
   // Dynamic routes
@@ -24,6 +26,7 @@ export const Route = {
   toOpportunity: (o: Pick<Opportunity, "slug">) => `/opportunities/${o.slug}`,
   toYouTubePlaylist: (playlistId: string) =>
     `https://www.youtube.com/playlist?list=${playlistId}`,
+  toMetric: (m: MetricDefinition) => `/stats/${m.slug}`
 };
 
 /** Site URL without trailing slash */


### PR DESCRIPTION
Přidané slugs pro Statistiky:
- Jednotlivé dlaždice s grafy na url /stats teď slouží jako linky na své vlastné detailní stránky
- Každá detialní stránka grafu má přichystaný basic layout
- Samotný graf na detailní stránce je teď pouze použitá komponenta MetricBox, což není finální řešení
